### PR TITLE
✨[FEAT] #58 : 찜 목록조회 수정

### DIFF
--- a/src/main/java/com/example/demo/domain/converter/LikeConverter.java
+++ b/src/main/java/com/example/demo/domain/converter/LikeConverter.java
@@ -42,7 +42,7 @@ public class LikeConverter {
         return LikeListResponseDTO.builder()
                 .likeId(like.getId())             // likeId
                 .raffleId(like.getRaffle().getId())         // raffleId
-                //.raffleStatus(like.getRaffle().getRaffleStatus().toString()) // raffleStatus
+                .raffleStatus(like.getRaffle().getRaffleStatus().toString()) // raffleStatus
                 .ticketNum(like.getRaffle().getTicketNum())    // ticketNum
                 .imageUrl(like.getRaffle().getImageUrl())       // imageUrl
                 .timeUntilEnd(timeUntilEnd)           // timeUntilEnd (남은 시간)

--- a/src/main/java/com/example/demo/domain/converter/LikeConverter.java
+++ b/src/main/java/com/example/demo/domain/converter/LikeConverter.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.converter;
 
+import com.example.demo.domain.dto.Like.LikeListResponseDTO;
 import com.example.demo.domain.dto.Like.LikeRequestDTO;
 import com.example.demo.domain.dto.Like.LikeResponseDTO;
 import com.example.demo.domain.dto.Review.ReviewRequestDTO;
@@ -8,7 +9,9 @@ import com.example.demo.entity.Like;
 import com.example.demo.entity.Raffle;
 import com.example.demo.entity.User;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class LikeConverter {
 
@@ -20,4 +23,27 @@ public class LikeConverter {
                 .raffleId(like.getRaffle().getId())
                 .build();
     }
+
+    public static LikeListResponseDTO toLikeListResponseDTO(Like like) {
+
+        Raffle raffle = like.getRaffle();
+        LocalDateTime endAt = raffle.getEndAt(); // raffle의 마감 시간
+        LocalDateTime now = LocalDateTime.now();
+
+        Duration duration = Duration.between(now,endAt);
+        // 남은 시간을 초 단위로 계산
+        long timeUntilEnd = duration.toMillis() / 1000;
+
+        return LikeListResponseDTO.builder()
+                .likeId(like.getId())             // likeId
+                .raffleId(like.getRaffle().getId())         // raffleId
+                //.raffleStatus(like.getRaffle().getRaffleStatus().toString()) // raffleStatus
+                .ticketNum(like.getRaffle().getTicketNum())    // ticketNum
+                .imageUrl(like.getRaffle().getImageUrl())       // imageUrl
+                .timeUntilEnd(timeUntilEnd)           // timeUntilEnd (남은 시간)
+                .raffleName(like.getRaffle().getName())         // raffleName
+                .userId(like.getUser().getId())      // userId
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/demo/domain/converter/LikeConverter.java
+++ b/src/main/java/com/example/demo/domain/converter/LikeConverter.java
@@ -8,13 +8,17 @@ import com.example.demo.domain.dto.Review.ReviewResponseDTO;
 import com.example.demo.entity.Like;
 import com.example.demo.entity.Raffle;
 import com.example.demo.entity.User;
+import com.example.demo.repository.ApplyRepository;
+import com.example.demo.repository.RaffleRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Component
 public class LikeConverter {
-
 
     public static LikeResponseDTO ToLikeResponseDTO(Like like) {
         return LikeResponseDTO.builder()
@@ -24,7 +28,7 @@ public class LikeConverter {
                 .build();
     }
 
-    public static LikeListResponseDTO toLikeListResponseDTO(Like like) {
+    public static LikeListResponseDTO toLikeListResponseDTO(Like like,int applyCount) {
 
         Raffle raffle = like.getRaffle();
         LocalDateTime endAt = raffle.getEndAt(); // raffle의 마감 시간
@@ -34,6 +38,7 @@ public class LikeConverter {
         // 남은 시간을 초 단위로 계산
         long timeUntilEnd = duration.toMillis() / 1000;
 
+
         return LikeListResponseDTO.builder()
                 .likeId(like.getId())             // likeId
                 .raffleId(like.getRaffle().getId())         // raffleId
@@ -42,7 +47,7 @@ public class LikeConverter {
                 .imageUrl(like.getRaffle().getImageUrl())       // imageUrl
                 .timeUntilEnd(timeUntilEnd)           // timeUntilEnd (남은 시간)
                 .raffleName(like.getRaffle().getName())         // raffleName
-                .userId(like.getUser().getId())      // userId
+                .applyCount(applyCount)
                 .build();
     }
 

--- a/src/main/java/com/example/demo/domain/dto/Like/LikeListResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Like/LikeListResponseDTO.java
@@ -14,23 +14,12 @@ public class LikeListResponseDTO {
     private String imageUrl;
     private Long timeUntilEnd;
     private String raffleName;
-    private Long userId;
+    private int applyCount;
 
 
     // Getter 메서드
-    public Long getLikeId() {
-        return likeId;
-    }
-
     public Long getRaffleId() {
         return raffleId;
     }
 
-    public String getRaffleName() {
-        return raffleName;
-    }
-
-    public Long getUserId() {
-        return userId;
-    }
 }

--- a/src/main/java/com/example/demo/domain/dto/Like/LikeListResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Like/LikeListResponseDTO.java
@@ -1,22 +1,21 @@
 package com.example.demo.domain.dto.Like;
 
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class LikeListResponseDTO {
 
     private Long likeId;
     private Long raffleId;
+    //private String raffleStatus;
+    private int ticketNum;
+    private String imageUrl;
+    private Long timeUntilEnd;
     private String raffleName;
     private Long userId;
 
-    // 생성자
-    public LikeListResponseDTO(Long likeId, Long rappleId, String raffleName, Long userId) {
-        this.likeId = likeId;
-        this.raffleId = rappleId;
-        this.raffleName = raffleName;
-        this.userId = userId;
-    }
 
     // Getter 메서드
     public Long getLikeId() {

--- a/src/main/java/com/example/demo/domain/dto/Like/LikeListResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Like/LikeListResponseDTO.java
@@ -9,7 +9,7 @@ public class LikeListResponseDTO {
 
     private Long likeId;
     private Long raffleId;
-    //private String raffleStatus;
+    private String raffleStatus;
     private int ticketNum;
     private String imageUrl;
     private Long timeUntilEnd;

--- a/src/main/java/com/example/demo/entity/Like.java
+++ b/src/main/java/com/example/demo/entity/Like.java
@@ -23,6 +23,7 @@ public class Like extends BaseEntity{
     @JoinColumn(name = "user_id")
     private User user;
 
+
     // 사용자 정의 생성자
     public Like(Raffle raffle, User user) {
         this.raffle = raffle;

--- a/src/main/java/com/example/demo/jobs/RaffleEndJob.java
+++ b/src/main/java/com/example/demo/jobs/RaffleEndJob.java
@@ -47,13 +47,13 @@ public class RaffleEndJob implements Job {
             updateRaffleStatus(raffle, RaffleStatus.UNFULFILLED);
 //            drawService.cancel(raffle, applyList);
 
-            updateRaffleStatus(raffle, RaffleStatus.ENDED);
+        updateRaffleStatus(raffle, RaffleStatus.ENDED);
 
-            if (applyList == null || applyList.isEmpty())
-                throw new CustomException(ErrorStatus.DRAW_EMPTY);
+        if (applyList == null || applyList.isEmpty())
+            throw new CustomException(ErrorStatus.DRAW_EMPTY);
 
-            Delivery delivery = drawService.draw(raffle, applyList);
+        Delivery delivery = drawService.draw(raffle, applyList);
 
-            emailService.sendEmail(delivery);
-        }
+        emailService.sendEmail(delivery);
     }
+}

--- a/src/main/java/com/example/demo/jobs/RaffleEndJob.java
+++ b/src/main/java/com/example/demo/jobs/RaffleEndJob.java
@@ -57,4 +57,3 @@ public class RaffleEndJob implements Job {
             emailService.sendEmail(delivery);
         }
     }
-}

--- a/src/main/java/com/example/demo/jobs/RaffleEndJob.java
+++ b/src/main/java/com/example/demo/jobs/RaffleEndJob.java
@@ -47,13 +47,14 @@ public class RaffleEndJob implements Job {
             updateRaffleStatus(raffle, RaffleStatus.UNFULFILLED);
 //            drawService.cancel(raffle, applyList);
 
-        updateRaffleStatus(raffle, RaffleStatus.ENDED);
+            updateRaffleStatus(raffle, RaffleStatus.ENDED);
 
-        if (applyList == null || applyList.isEmpty())
-            throw new CustomException(ErrorStatus.DRAW_EMPTY);
+            if (applyList == null || applyList.isEmpty())
+                throw new CustomException(ErrorStatus.DRAW_EMPTY);
 
-        Delivery delivery = drawService.draw(raffle, applyList);
+            Delivery delivery = drawService.draw(raffle, applyList);
 
-        emailService.sendEmail(delivery);
+            emailService.sendEmail(delivery);
+        }
     }
 }

--- a/src/main/java/com/example/demo/repository/ApplyRepository.java
+++ b/src/main/java/com/example/demo/repository/ApplyRepository.java
@@ -6,10 +6,12 @@ import com.example.demo.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
+@Repository
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     int countByRaffle(Raffle raffle);

--- a/src/main/java/com/example/demo/repository/LikeRepository.java
+++ b/src/main/java/com/example/demo/repository/LikeRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     // 특정 사용자가 찜한 raffleId 목록 조회
-    List<Like> findByUserId(Long userId);
+    List<Like> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     Optional<Like> findByUserIdAndRaffleId(Long userId, Long raffleId);
 

--- a/src/main/java/com/example/demo/service/general/LikeService.java
+++ b/src/main/java/com/example/demo/service/general/LikeService.java
@@ -26,7 +26,6 @@ public interface LikeService {
 
     //찜 목록 조회
     List<LikeListResponseDTO> getLikedItems(Long userId);
-
     //찜 수 조회
     Long getLikeCount(Long raffleId);
 

--- a/src/main/java/com/example/demo/service/general/impl/LikeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/LikeServiceImpl.java
@@ -36,15 +36,6 @@ public class LikeServiceImpl implements LikeService {
     private final UserRepository userRepository;
     private final ApplyRepository applyRepository;
 
-    @Autowired
-    public LikeServiceImpl(LikeRepository likeRepository, ApplyRepository applyRepository, RaffleRepository raffleRepository,UserRepository userRepository) {
-        this.likeRepository = likeRepository;
-        this.applyRepository = applyRepository;
-        this.raffleRepository = raffleRepository;
-        this.userRepository = userRepository;
-    }
-
-
     // 찜하기
     public LikeResponseDTO addLike(Long raffleId, LikeRequestDTO likeRequest) {
 

--- a/src/main/java/com/example/demo/service/general/impl/LikeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/LikeServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.demo.domain.dto.Review.ReviewResponseDTO;
 import com.example.demo.entity.Like;
 import com.example.demo.entity.Raffle;
 import com.example.demo.entity.User;
+import com.example.demo.repository.ApplyRepository;
 import com.example.demo.repository.LikeRepository;
 import com.example.demo.repository.RaffleRepository;
 import com.example.demo.repository.UserRepository;
@@ -20,7 +21,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,6 +34,16 @@ public class LikeServiceImpl implements LikeService {
     private final LikeRepository likeRepository;
     private final RaffleRepository raffleRepository;
     private final UserRepository userRepository;
+    private final ApplyRepository applyRepository;
+
+    @Autowired
+    public LikeServiceImpl(LikeRepository likeRepository, ApplyRepository applyRepository, RaffleRepository raffleRepository,UserRepository userRepository) {
+        this.likeRepository = likeRepository;
+        this.applyRepository = applyRepository;
+        this.raffleRepository = raffleRepository;
+        this.userRepository = userRepository;
+    }
+
 
     // 찜하기
     public LikeResponseDTO addLike(Long raffleId, LikeRequestDTO likeRequest) {
@@ -68,13 +81,34 @@ public class LikeServiceImpl implements LikeService {
     }
 
     // 찜 목록 조회
+    @Override
     @Transactional(readOnly = true)
     public List<LikeListResponseDTO> getLikedItems(Long userId) {
         List<Like> likes = likeRepository.findByUserIdOrderByCreatedAtDesc(userId);
 
-        return likes.stream()
-                .map(LikeConverter::toLikeListResponseDTO) // 변환 메서드 사용
+        // 찜 목록에 포함된 raffleId들 추출
+        List<Long> raffleIds = likes.stream()
+                .map(like -> like.getRaffle().getId())
                 .collect(Collectors.toList());
+
+        // 각 raffleId에 대해 응모 횟수 조회
+        List<Object[]> applyCounts = applyRepository.countAppliesByRaffleIds(raffleIds);
+
+        Map<Long, Long> applyCountMap = new HashMap<>();
+        for (Object[] result : applyCounts) {
+            Long raffleId = (Long) result[0];
+            Long applyCount = (Long) result[1];
+            applyCountMap.put(raffleId, applyCount);
+        }
+
+        return likes.stream()
+                .map(like -> {
+                    Long raffleId = like.getRaffle().getId();
+                    int applyCount = applyCountMap.getOrDefault(raffleId, 0L).intValue(); // 응모 횟수 조회
+                    return LikeConverter.toLikeListResponseDTO(like, applyCount); // 응모 횟수 추가
+                })
+                .collect(Collectors.toList());
+
     }
 
     //찜 수 조회

--- a/src/main/java/com/example/demo/service/general/impl/LikeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/LikeServiceImpl.java
@@ -70,18 +70,11 @@ public class LikeServiceImpl implements LikeService {
     // 찜 목록 조회
     @Transactional(readOnly = true)
     public List<LikeListResponseDTO> getLikedItems(Long userId) {
-        List<Like> likes = likeRepository.findByUserId(userId);
+        List<Like> likes = likeRepository.findByUserIdOrderByCreatedAtDesc(userId);
 
         return likes.stream()
-                .map(like -> {
-                    Raffle raffle = like.getRaffle();
-                    return new LikeListResponseDTO(
-                            like.getId(),            // likeId
-                            raffle.getId(),          // raffleId
-                            raffle.getName(),        // productName
-                            like.getUser().getId()   // userId
-                    );
-                }).collect(Collectors.toList());
+                .map(LikeConverter::toLikeListResponseDTO) // 변환 메서드 사용
+                .collect(Collectors.toList());
     }
 
     //찜 수 조회


### PR DESCRIPTION
## #⃣ 연관된 이슈

#58
close #58

## 📝 작업 내용

![image](https://github.com/user-attachments/assets/bd110fdf-3421-4f24-bf0e-4a0cfd766466)

찜한 래플 조회에 래플 대표사진/마감까지 남은 시간/래플 이름/응모상태/응모자 수/티켓 갯수까지 조회할 수 있도록 수정했습니다
그리고 찜 목록은 created_at 순으로 조회되도록 했습니다

### 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/e772902b-a6d5-448f-b1db-6129fcfbf3a9)

## 💬 리뷰 요구사항(선택)
