### PR TITLE
✨[FEAT] #76: 팔로우한 상점 래플 더보기 + 래플 둘러보기 + 내가 찜한 래플 더보기

### DIFF
--- a/src/main/java/com/example/demo/controller/general/HomeController.java
+++ b/src/main/java/com/example/demo/controller/general/HomeController.java
@@ -1,6 +1,7 @@
 package com.example.demo.controller.general;
 
 import com.example.demo.base.ApiResponse;
+import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.base.status.SuccessStatus;
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
 import com.example.demo.domain.dto.Home.HomeResponseDTO;
@@ -73,6 +74,21 @@ public class HomeController {
             return ApiResponse.of(SuccessStatus._OK, result);
         }
     }
+
+    @Operation(summary = "팔로우한 상점의 래플 더보기")
+    @GetMapping("/following")
+    public ApiResponse<HomeRaffleListDTO> homeFollowingRaffles(Authentication authentication){
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ApiResponse.onFailure(ErrorStatus.COMMON_UNAUTHORIZED, null);
+        }
+
+        Long userId = Long.parseLong(authentication.getName());
+        HomeRaffleListDTO result = homeService.getHomeFollowingRaffles(userId);
+        return ApiResponse.of(SuccessStatus._OK, result);
+    }
+
+
 
 
 }

--- a/src/main/java/com/example/demo/controller/general/HomeController.java
+++ b/src/main/java/com/example/demo/controller/general/HomeController.java
@@ -1,6 +1,7 @@
 package com.example.demo.controller.general;
 
 import com.example.demo.base.ApiResponse;
+import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.base.status.SuccessStatus;
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
 import com.example.demo.domain.dto.Home.HomeResponseDTO;
@@ -77,6 +78,10 @@ public class HomeController {
     @Operation(summary = "팔로우한 상점의 래플 더보기")
     @GetMapping("/following")
     public ApiResponse<HomeRaffleListDTO> homeFollowingRaffles(Authentication authentication){
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ApiResponse.onFailure(ErrorStatus.COMMON_UNAUTHORIZED, null);
+        }
+
         Long userId = Long.parseLong(authentication.getName());
         HomeRaffleListDTO result = homeService.getHomeFollowingRaffles(userId);
         return ApiResponse.of(SuccessStatus._OK, result);
@@ -99,6 +104,18 @@ public class HomeController {
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
+    }
+
+    @Operation(summary = "내가 찜한 래플 더보기")
+    @GetMapping("/likes")
+    public ApiResponse<HomeRaffleListDTO> homeLikeRaffles(Authentication authentication){
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ApiResponse.onFailure(ErrorStatus.COMMON_UNAUTHORIZED, null);
+        }
+
+        Long userId = Long.parseLong(authentication.getName());
+        HomeRaffleListDTO result = homeService.getHomeLikeRaffles(userId);
+        return ApiResponse.of(SuccessStatus._OK, result);
     }
 
 

--- a/src/main/java/com/example/demo/controller/general/HomeController.java
+++ b/src/main/java/com/example/demo/controller/general/HomeController.java
@@ -22,13 +22,13 @@ public class HomeController {
     @GetMapping("")
     public ApiResponse<HomeResponseDTO> home(Authentication authentication){
 
-        // 로그인 한 회원인 경우
+        // 로그인 안한 회원인 경우
         if (authentication == null || !authentication.isAuthenticated()) {
             HomeResponseDTO result = homeService.getHome();
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
-        // 로그인 안한 회원인 경우
+        // 로그인 한 회원인 경우
         else{
             Long userId = Long.parseLong(authentication.getName());
             HomeResponseDTO result =  homeService.getHomeLogin(userId);
@@ -41,13 +41,13 @@ public class HomeController {
     @GetMapping("/categories")
     public ApiResponse<HomeRaffleListDTO> homeCategories(@RequestParam("categoryName") String categoryName, Authentication authentication){
 
-        // 로그인 한 회원인 경우
+        // 로그인 안한 회원인 경우
         if (authentication == null || !authentication.isAuthenticated()) {
             HomeRaffleListDTO result = homeService.getHomeCategories(categoryName);
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
-        // 로그인 안한 회원인 경우
+        // 로그인 한 회원인 경우
         else{
             Long userId = Long.parseLong(authentication.getName());
             HomeRaffleListDTO result =  homeService.getHomeCategoriesLogin(categoryName, userId);
@@ -60,13 +60,13 @@ public class HomeController {
     @GetMapping("/approaching")
     public ApiResponse<HomeRaffleListDTO> homeApproaching(Authentication authentication){
 
-        // 로그인 한 회원인 경우
+        // 로그인 안한 회원인 경우
         if (authentication == null || !authentication.isAuthenticated()) {
             HomeRaffleListDTO result = homeService.getHomeApproaching();
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
-        // 로그인 안 한 회원인 경우
+        // 로그인 한 회원인 경우
         else{
             Long userId = Long.parseLong(authentication.getName());
             HomeRaffleListDTO result =  homeService.getHomeApproachingLogin(userId);

--- a/src/main/java/com/example/demo/controller/general/HomeController.java
+++ b/src/main/java/com/example/demo/controller/general/HomeController.java
@@ -1,7 +1,6 @@
 package com.example.demo.controller.general;
 
 import com.example.demo.base.ApiResponse;
-import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.base.status.SuccessStatus;
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
 import com.example.demo.domain.dto.Home.HomeResponseDTO;

--- a/src/main/java/com/example/demo/controller/general/HomeController.java
+++ b/src/main/java/com/example/demo/controller/general/HomeController.java
@@ -78,17 +78,29 @@ public class HomeController {
     @Operation(summary = "팔로우한 상점의 래플 더보기")
     @GetMapping("/following")
     public ApiResponse<HomeRaffleListDTO> homeFollowingRaffles(Authentication authentication){
-
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return ApiResponse.onFailure(ErrorStatus.COMMON_UNAUTHORIZED, null);
-        }
-
         Long userId = Long.parseLong(authentication.getName());
         HomeRaffleListDTO result = homeService.getHomeFollowingRaffles(userId);
         return ApiResponse.of(SuccessStatus._OK, result);
     }
 
+    @Operation(summary = "래플 둘러보기")
+    @GetMapping("/more")
+    public ApiResponse<HomeRaffleListDTO> homeMoreRaffles(Authentication authentication){
 
+        // 로그인 안한 회원인 경우
+        if (authentication == null || !authentication.isAuthenticated()) {
+            HomeRaffleListDTO result = homeService.getHomeMoreRaffles();
+            return ApiResponse.of(SuccessStatus._OK, result);
+        }
+
+        // 로그인 한 회원인 경우
+        else{
+            Long userId = Long.parseLong(authentication.getName());
+            HomeRaffleListDTO result =  homeService.getHomeMoreRafflesLogin(userId);
+            return ApiResponse.of(SuccessStatus._OK, result);
+        }
+
+    }
 
 
 }

--- a/src/main/java/com/example/demo/controller/general/HomeController.java
+++ b/src/main/java/com/example/demo/controller/general/HomeController.java
@@ -3,6 +3,7 @@ package com.example.demo.controller.general;
 import com.example.demo.base.ApiResponse;
 import com.example.demo.base.status.SuccessStatus;
 import com.example.demo.domain.dto.Home.HomeCategoryResponseDTO;
+import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
 import com.example.demo.domain.dto.Home.HomeResponseDTO;
 import com.example.demo.service.general.HomeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,13 +51,13 @@ public class HomeController {
 
     @Operation(summary = "카테고리별 래플 조회")
     @GetMapping("/categories")
-    public ApiResponse<HomeCategoryResponseDTO> homeCategories(@RequestParam("categoryName") String categoryName){
+    public ApiResponse<HomeRaffleListDTO> homeCategories(@RequestParam("categoryName") String categoryName){
 
         // TODO: 로그인 한 회원인지 찾는 로직, 이후에 수정 예정.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
-            HomeCategoryResponseDTO result = homeService.getHomeCategories(categoryName);
+            HomeRaffleListDTO result = homeService.getHomeCategories(categoryName);
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
@@ -68,10 +69,17 @@ public class HomeController {
             if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
                 email = (String) kakaoAccount.get("email");
             }
-            HomeCategoryResponseDTO result =  homeService.getHomeCategoriesLogin(categoryName, email);
+            HomeRaffleListDTO result =  homeService.getHomeCategoriesLogin(categoryName, email);
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
     }
+
+    @Operation(summary = "마감임박 상품 더보기")
+    @GetMapping("/approaching")
+    public ApiResponse<HomeRaffleListDTO> homeApproaching(){
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
 
 }

--- a/src/main/java/com/example/demo/controller/general/HomeController.java
+++ b/src/main/java/com/example/demo/controller/general/HomeController.java
@@ -2,18 +2,13 @@ package com.example.demo.controller.general;
 
 import com.example.demo.base.ApiResponse;
 import com.example.demo.base.status.SuccessStatus;
-import com.example.demo.domain.dto.Home.HomeCategoryResponseDTO;
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
 import com.example.demo.domain.dto.Home.HomeResponseDTO;
 import com.example.demo.service.general.HomeService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 
 @RestController
@@ -25,25 +20,18 @@ public class HomeController {
 
     @Operation(summary = "홈 화면 조회")
     @GetMapping("")
-    public ApiResponse<HomeResponseDTO> home(){
+    public ApiResponse<HomeResponseDTO> home(Authentication authentication){
 
-        // TODO: 로그인 한 회원인지 찾는 로직, 이후에 수정 예정.
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
+        // 로그인 한 회원인 경우
+        if (authentication == null || !authentication.isAuthenticated()) {
             HomeResponseDTO result = homeService.getHome();
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
+        // 로그인 안한 회원인 경우
         else{
-            DefaultOAuth2User principal = (DefaultOAuth2User) authentication.getPrincipal();
-            Map<String, Object> attributes = principal.getAttributes();
-            String email = null;
-            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-            if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
-                email = (String) kakaoAccount.get("email");
-            }
-            HomeResponseDTO result =  homeService.getHomeLogin(email);
+            Long userId = Long.parseLong(authentication.getName());
+            HomeResponseDTO result =  homeService.getHomeLogin(userId);
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
@@ -51,25 +39,18 @@ public class HomeController {
 
     @Operation(summary = "카테고리별 래플 조회")
     @GetMapping("/categories")
-    public ApiResponse<HomeRaffleListDTO> homeCategories(@RequestParam("categoryName") String categoryName){
+    public ApiResponse<HomeRaffleListDTO> homeCategories(@RequestParam("categoryName") String categoryName, Authentication authentication){
 
-        // TODO: 로그인 한 회원인지 찾는 로직, 이후에 수정 예정.
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
+        // 로그인 한 회원인 경우
+        if (authentication == null || !authentication.isAuthenticated()) {
             HomeRaffleListDTO result = homeService.getHomeCategories(categoryName);
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
+        // 로그인 안한 회원인 경우
         else{
-            DefaultOAuth2User principal = (DefaultOAuth2User) authentication.getPrincipal();
-            Map<String, Object> attributes = principal.getAttributes();
-            String email = null;
-            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-            if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
-                email = (String) kakaoAccount.get("email");
-            }
-            HomeRaffleListDTO result =  homeService.getHomeCategoriesLogin(categoryName, email);
+            Long userId = Long.parseLong(authentication.getName());
+            HomeRaffleListDTO result =  homeService.getHomeCategoriesLogin(categoryName, userId);
             return ApiResponse.of(SuccessStatus._OK, result);
         }
 
@@ -77,8 +58,20 @@ public class HomeController {
 
     @Operation(summary = "마감임박 상품 더보기")
     @GetMapping("/approaching")
-    public ApiResponse<HomeRaffleListDTO> homeApproaching(){
-        return ApiResponse.of(SuccessStatus._OK, null);
+    public ApiResponse<HomeRaffleListDTO> homeApproaching(Authentication authentication){
+
+        // 로그인 한 회원인 경우
+        if (authentication == null || !authentication.isAuthenticated()) {
+            HomeRaffleListDTO result = homeService.getHomeApproaching();
+            return ApiResponse.of(SuccessStatus._OK, result);
+        }
+
+        // 로그인 안 한 회원인 경우
+        else{
+            Long userId = Long.parseLong(authentication.getName());
+            HomeRaffleListDTO result =  homeService.getHomeApproachingLogin(userId);
+            return ApiResponse.of(SuccessStatus._OK, result);
+        }
     }
 
 

--- a/src/main/java/com/example/demo/domain/dto/Home/HomeApproachingResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Home/HomeApproachingResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.demo.domain.dto.Home;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeApproachingResponseDTO {
+
+    List<HomeRaffleDTO> approaching;
+
+}

--- a/src/main/java/com/example/demo/domain/dto/Home/HomeRaffleListDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Home/HomeRaffleListDTO.java
@@ -1,0 +1,16 @@
+package com.example.demo.domain.dto.Home;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeRaffleListDTO {
+    private List<HomeRaffleDTO> raffles;
+}

--- a/src/main/java/com/example/demo/service/general/HomeService.java
+++ b/src/main/java/com/example/demo/service/general/HomeService.java
@@ -18,4 +18,8 @@ public interface HomeService {
     HomeRaffleListDTO getHomeApproachingLogin(Long userId);
 
     HomeRaffleListDTO getHomeFollowingRaffles(Long userId);
+
+    HomeRaffleListDTO getHomeMoreRaffles();
+
+    HomeRaffleListDTO getHomeMoreRafflesLogin(Long userId);
 }

--- a/src/main/java/com/example/demo/service/general/HomeService.java
+++ b/src/main/java/com/example/demo/service/general/HomeService.java
@@ -1,7 +1,5 @@
 package com.example.demo.service.general;
 
-import com.example.demo.domain.dto.Home.HomeApproachingResponseDTO;
-import com.example.demo.domain.dto.Home.HomeCategoryResponseDTO;
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
 import com.example.demo.domain.dto.Home.HomeResponseDTO;
 
@@ -9,11 +7,13 @@ public interface HomeService {
 
     HomeResponseDTO getHome();
 
-    HomeResponseDTO getHomeLogin(String email);
+    HomeResponseDTO getHomeLogin(Long userId);
 
     HomeRaffleListDTO getHomeCategories(String categoryName);
 
-    HomeRaffleListDTO getHomeCategoriesLogin(String categoryName, String email);
+    HomeRaffleListDTO getHomeCategoriesLogin(String categoryName, Long userId);
 
     HomeRaffleListDTO getHomeApproaching();
+
+    HomeRaffleListDTO getHomeApproachingLogin(Long userId);
 }

--- a/src/main/java/com/example/demo/service/general/HomeService.java
+++ b/src/main/java/com/example/demo/service/general/HomeService.java
@@ -16,4 +16,6 @@ public interface HomeService {
     HomeRaffleListDTO getHomeApproaching();
 
     HomeRaffleListDTO getHomeApproachingLogin(Long userId);
+
+    HomeRaffleListDTO getHomeFollowingRaffles(Long userId);
 }

--- a/src/main/java/com/example/demo/service/general/HomeService.java
+++ b/src/main/java/com/example/demo/service/general/HomeService.java
@@ -1,6 +1,8 @@
 package com.example.demo.service.general;
 
+import com.example.demo.domain.dto.Home.HomeApproachingResponseDTO;
 import com.example.demo.domain.dto.Home.HomeCategoryResponseDTO;
+import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
 import com.example.demo.domain.dto.Home.HomeResponseDTO;
 
 public interface HomeService {
@@ -9,7 +11,9 @@ public interface HomeService {
 
     HomeResponseDTO getHomeLogin(String email);
 
-    HomeCategoryResponseDTO getHomeCategories(String categoryName);
+    HomeRaffleListDTO getHomeCategories(String categoryName);
 
-    HomeCategoryResponseDTO getHomeCategoriesLogin(String categoryName, String email);
+    HomeRaffleListDTO getHomeCategoriesLogin(String categoryName, String email);
+
+    HomeRaffleListDTO getHomeApproaching();
 }

--- a/src/main/java/com/example/demo/service/general/HomeService.java
+++ b/src/main/java/com/example/demo/service/general/HomeService.java
@@ -22,4 +22,6 @@ public interface HomeService {
     HomeRaffleListDTO getHomeMoreRaffles();
 
     HomeRaffleListDTO getHomeMoreRafflesLogin(Long userId);
+
+    HomeRaffleListDTO getHomeLikeRaffles(Long userId);
 }

--- a/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
@@ -37,57 +37,29 @@ public class HomeServiceImpl implements HomeService {
         List<Raffle> raffles = raffleRepository.findAll();
 
         // 마감임박인 래플 5개 조회 (로그인 안 했을 시)
-        LocalDateTime now = LocalDateTime.now();
+        List<Raffle> rafflesSortedByEndAt = sortRafflesByEndAt(raffles, 5);
 
-        List<Raffle> rafflesSortedByEndAt = raffles.stream()
-                .filter(r -> Duration.between(now, r.getEndAt()).toMillis() >= 0)
-                .sorted(Comparator.comparingLong(r -> Duration.between(now, r.getEndAt()).toMillis()))
-                .limit(5)
-                .toList();
-
-        List<HomeRaffleDTO> rafflesSortedByEndAtDTO = new ArrayList<>();
-
-        for (Raffle raffle : rafflesSortedByEndAt) {
-            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, false);
-            rafflesSortedByEndAtDTO.add(raffleDTO);
-        }
+        List<HomeRaffleDTO> rafflesSortedByEndAtDTO = convertToHomeRaffleDTOList(rafflesSortedByEndAt, null);
 
         // 래플 둘러보기 -> 응모자순으로 래플 조회 (응모 안마감된것 우선, 로그인 안 했을 시)
-        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles, now);
-
-        List<HomeRaffleDTO> rafflesSortedByApplyListDTO = new ArrayList<>();
-
-        for (Raffle raffle : rafflesSortedByApplyList) {
-            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, false);
-            rafflesSortedByApplyListDTO.add(raffleDTO);
-        }
+        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles);
+        List<HomeRaffleDTO> rafflesSortedByApplyListDTO = convertToHomeRaffleDTOList(rafflesSortedByApplyList, null);
 
         return getHomeResponseDTO(rafflesSortedByEndAtDTO, null, null, rafflesSortedByApplyListDTO);
     }
 
     @Override
-    public HomeResponseDTO getHomeLogin(String email){
+    public HomeResponseDTO getHomeLogin(Long userId){
 
         List<Raffle> raffles = raffleRepository.findAll();
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
-
-        // 마감임박인 래플 5개 조회 (로그인 했을 시, 본인이 찜한 여부까지 같이 전달)
         LocalDateTime now = LocalDateTime.now();
 
-        List<Raffle> rafflesSortedByEndAt = raffles.stream()
-                .filter(r -> Duration.between(now, r.getEndAt()).toMillis() >= 0)
-                .sorted(Comparator.comparingLong(r -> Duration.between(now, r.getEndAt()).toMillis()))
-                .limit(5)
-                .toList();
+        // 마감임박인 래플 5개 조회 (로그인 했을 시, 본인이 찜한 여부까지 같이 전달)
+        List<Raffle> rafflesSortedByEndAt = sortRafflesByEndAt(raffles, 5);
+        List<HomeRaffleDTO> rafflesSortedByEndAtDTO = convertToHomeRaffleDTOList(rafflesSortedByEndAt, user);
 
-        List<HomeRaffleDTO> rafflesSortedByEndAtDTO = new ArrayList<>();
-
-        for (Raffle raffle : rafflesSortedByEndAt) {
-            boolean likeStatus = likeRepository.findByUserIdAndRaffleId(user.getId(), raffle.getId()).isPresent();
-            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, likeStatus);
-            rafflesSortedByEndAtDTO.add(raffleDTO);
-        }
 
         // 내가 찜한 래플 5개 조회 ( 로그인 했을 시 기능 )
         List<Like> sortedLikes = user.getLikes().stream()
@@ -113,31 +85,13 @@ public class HomeServiceImpl implements HomeService {
             followingAllRaffles.addAll(followingRaffles);
         }
 
-        List<Raffle> myFollowRaffles = followingAllRaffles.stream()
-                .filter(r -> Duration.between(now, r.getEndAt()).toMillis() >= 0)
-                .sorted(Comparator.comparingLong(r -> Duration.between(now, r.getEndAt()).toMillis()))
-                .limit(5)
-                .toList();
-
-        List<HomeRaffleDTO> myFollowingRafflesDTO = new ArrayList<>();
-
-        for (Raffle raffle : myFollowRaffles) {
-            boolean likeStatus = likeRepository.findByUserIdAndRaffleId(user.getId(), raffle.getId()).isPresent();
-            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, likeStatus);
-            myFollowingRafflesDTO.add(raffleDTO);
-        }
+        List<Raffle> myFollowRaffles = sortRafflesByEndAt(followingAllRaffles, 5);
+        List<HomeRaffleDTO> myFollowingRafflesDTO = convertToHomeRaffleDTOList(myFollowRaffles, user);
 
 
         // 래플 둘러보기 -> 응모자순으로 래플 조회 (응모 안마감된것 우선, 로그인 했을 시 찜 여부도 같이 전달)
-        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles, now);
-
-        List<HomeRaffleDTO> rafflesSortedByApplyListDTO = new ArrayList<>();
-
-        for (Raffle raffle : rafflesSortedByApplyList) {
-            boolean likeStatus = likeRepository.findByUserIdAndRaffleId(user.getId(), raffle.getId()).isPresent();
-            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, likeStatus);
-            rafflesSortedByApplyListDTO.add(raffleDTO);
-        }
+        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles);
+        List<HomeRaffleDTO> rafflesSortedByApplyListDTO = convertToHomeRaffleDTOList(rafflesSortedByApplyList, user);
 
 
         return getHomeResponseDTO(rafflesSortedByEndAtDTO, myLikeRafflesDTO, myFollowingRafflesDTO, rafflesSortedByApplyListDTO);
@@ -150,44 +104,30 @@ public class HomeServiceImpl implements HomeService {
         Category category = categoryRepository.findByName(categoryName)
                 .orElseThrow(() -> new CustomException(ErrorStatus.COMMON_WRONG_PARAMETER));
 
-        List<Raffle> raffles = raffleRepository.findByCategoryName(categoryName);
-        LocalDateTime now = LocalDateTime.now();
-        List<HomeRaffleDTO> result = new ArrayList<>();
+        List<Raffle> raffles = raffleRepository.findByCategoryName(category.getName());
 
         // 카테고리별 조회 + 응모자순으로 래플 조회 (응모 안마감된것 우선)
-        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles, now);
-
-        for (Raffle raffle : rafflesSortedByApplyList) {
-            HomeRaffleDTO homeRaffleDTO = HomeConverter.toHomeRaffleDTO(raffle, false);
-            result.add(homeRaffleDTO);
-        }
+        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles);
+        List<HomeRaffleDTO> result = convertToHomeRaffleDTOList(rafflesSortedByApplyList, null);
 
         return HomeRaffleListDTO.builder()
                 .raffles(result).build();
-
     }
 
     @Override
-    public HomeRaffleListDTO getHomeCategoriesLogin(String categoryName, String email) {
+    public HomeRaffleListDTO getHomeCategoriesLogin(String categoryName, Long userId) {
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
 
         Category category = categoryRepository.findByName(categoryName)
                 .orElseThrow(() -> new CustomException(ErrorStatus.COMMON_WRONG_PARAMETER));
 
         List<Raffle> raffles = raffleRepository.findByCategoryName(categoryName);
-        LocalDateTime now = LocalDateTime.now();
-        List<HomeRaffleDTO> result = new ArrayList<>();
 
         // 카테고리별 조회 + 응모자순으로 래플 조회 (응모 안마감된것 우선)
-        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles, now);
-
-        for (Raffle raffle : rafflesSortedByApplyList) {
-            boolean likeStatus = likeRepository.findByUserIdAndRaffleId(user.getId(), raffle.getId()).isPresent();
-            HomeRaffleDTO homeRaffleDTO = HomeConverter.toHomeRaffleDTO(raffle, likeStatus);
-            result.add(homeRaffleDTO);
-        }
+        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles);
+        List<HomeRaffleDTO> result = convertToHomeRaffleDTOList(rafflesSortedByApplyList, user);
 
         return HomeRaffleListDTO.builder()
                 .raffles(result).build();
@@ -199,19 +139,25 @@ public class HomeServiceImpl implements HomeService {
         List<Raffle> raffles = raffleRepository.findAll();
 
         // 마감임박인 래플 더보기 조회
-        LocalDateTime now = LocalDateTime.now();
+        List<Raffle> rafflesSortedByEndAt = sortRafflesByEndAt(raffles, null);
+        List<HomeRaffleDTO> rafflesSortedByEndAtDTO = convertToHomeRaffleDTOList(rafflesSortedByEndAt, null);
 
-        List<Raffle> rafflesSortedByEndAt = raffles.stream()
-                .filter(r -> Duration.between(now, r.getEndAt()).toMillis() >= 0)
-                .sorted(Comparator.comparingLong(r -> Duration.between(now, r.getEndAt()).toMillis()))
-                .toList();
+        return HomeRaffleListDTO.builder()
+                .raffles(rafflesSortedByEndAtDTO)
+                .build();
+    }
 
-        List<HomeRaffleDTO> rafflesSortedByEndAtDTO = new ArrayList<>();
+    @Override
+    public HomeRaffleListDTO getHomeApproachingLogin(Long userId) {
 
-        for (Raffle raffle : rafflesSortedByEndAt) {
-            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, false);
-            rafflesSortedByEndAtDTO.add(raffleDTO);
-        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Raffle> raffles = raffleRepository.findAll();
+
+        // 마감임박인 래플 더보기 조회
+        List<Raffle> rafflesSortedByEndAt = sortRafflesByEndAt(raffles, null);
+        List<HomeRaffleDTO> rafflesSortedByEndAtDTO = convertToHomeRaffleDTOList(rafflesSortedByEndAt, user);
 
         return HomeRaffleListDTO.builder()
                 .raffles(rafflesSortedByEndAtDTO)
@@ -225,7 +171,8 @@ public class HomeServiceImpl implements HomeService {
     * */
 
     // 응모 마감 안된것 + 응모자순으로 정렬하는 로직
-    private List<Raffle> sortRafflesByApply(List<Raffle> raffles, LocalDateTime now) {
+    private List<Raffle> sortRafflesByApply(List<Raffle> raffles) {
+        LocalDateTime now = LocalDateTime.now();
         return Stream.concat(
                 raffles.stream()
                         .filter(r -> Duration.between(now, r.getEndAt()).toMillis() >= 0)
@@ -250,6 +197,44 @@ public class HomeServiceImpl implements HomeService {
                 .myFollowRaffles(myFollowingRafflesDTO)
                 .raffles(rafflesSortedByApplyListDTO)
                 .build();
+    }
+
+    private List<HomeRaffleDTO> convertToHomeRaffleDTOList(List<Raffle> raffles, User user) {
+        List<HomeRaffleDTO> dtoList = new ArrayList<>();
+
+        for (Raffle raffle : raffles) {
+            boolean likeStatus = false;
+
+            // 로그인한 경우에만 likeStatus 조회
+            if (user != null) {
+                likeStatus = likeRepository.findByUserIdAndRaffleId(user.getId(), raffle.getId()).isPresent();
+            }
+
+            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, likeStatus);
+            dtoList.add(raffleDTO);
+        }
+
+        return dtoList;
+    }
+
+    private List<Raffle> sortRafflesByEndAt(List<Raffle> raffles, Integer limit){
+        LocalDateTime now = LocalDateTime.now();
+
+        if(limit != null){
+            return raffles.stream()
+                    .filter(r -> Duration.between(now, r.getEndAt()).toMillis() >= 0)
+                    .sorted(Comparator.comparingLong(r -> Duration.between(now, r.getEndAt()).toMillis()))
+                    .limit(limit)
+                    .toList();
+        }
+
+        else{
+            return raffles.stream()
+                    .filter(r -> Duration.between(now, r.getEndAt()).toMillis() >= 0)
+                    .sorted(Comparator.comparingLong(r -> Duration.between(now, r.getEndAt()).toMillis()))
+                    .toList();
+        }
+
     }
 
 }

--- a/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
@@ -188,6 +188,31 @@ public class HomeServiceImpl implements HomeService {
                 .build();
     }
 
+    @Override
+    public HomeRaffleListDTO getHomeMoreRaffles() {
+        List<Raffle> raffles = raffleRepository.findAll();
+        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles);
+        List<HomeRaffleDTO> rafflesSortedByApplyListDTO = convertToHomeRaffleDTOList(rafflesSortedByApplyList, null);
+
+        return HomeRaffleListDTO.builder()
+                .raffles(rafflesSortedByApplyListDTO)
+                .build();
+    }
+
+    @Override
+    public HomeRaffleListDTO getHomeMoreRafflesLogin(Long userId) {
+        List<Raffle> raffles = raffleRepository.findAll();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles);
+        List<HomeRaffleDTO> rafflesSortedByApplyListDTO = convertToHomeRaffleDTOList(rafflesSortedByApplyList, user);
+
+        return HomeRaffleListDTO.builder()
+                .raffles(rafflesSortedByApplyListDTO)
+                .build();
+    }
+
 
     /**
      * 사용하는 메소드 분리

--- a/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
@@ -165,6 +165,29 @@ public class HomeServiceImpl implements HomeService {
 
     }
 
+    @Override
+    public HomeRaffleListDTO getHomeFollowingRaffles(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Follow> followings = user.getFollowings();
+        List<Raffle> followingAllRaffles = new ArrayList<>();
+
+
+        for (Follow following : followings) {
+            List<Raffle> followingRaffles = following.getUser().getRaffles();
+            followingAllRaffles.addAll(followingRaffles);
+        }
+
+        List<Raffle> myFollowRaffles = sortRafflesByEndAt(followingAllRaffles, 5);
+        List<HomeRaffleDTO> myFollowingRafflesDTO = convertToHomeRaffleDTOList(myFollowRaffles, user);
+
+        return HomeRaffleListDTO.builder()
+                .raffles(myFollowingRafflesDTO)
+                .build();
+    }
+
 
     /**
      * 사용하는 메소드 분리

--- a/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
@@ -213,6 +213,29 @@ public class HomeServiceImpl implements HomeService {
                 .build();
     }
 
+    @Override
+    public HomeRaffleListDTO getHomeLikeRaffles(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Like> sortedLikes = user.getLikes().stream()
+                .sorted(Comparator.comparing(Like::getCreatedAt).reversed())
+                .toList();
+
+        List<HomeRaffleDTO> myLikeRafflesDTO = new ArrayList<>();
+
+        for (Like sortedLike : sortedLikes) {
+            Raffle raffle = sortedLike.getRaffle();
+            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, true);
+            myLikeRafflesDTO.add(raffleDTO);
+        }
+
+        return HomeRaffleListDTO.builder()
+                .raffles(myLikeRafflesDTO)
+                .build();
+    }
+
 
     /**
      * 사용하는 메소드 분리

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,7 +76,7 @@ spring:
             client-id: af7f76095596a2c3c083f5a6d5b055f8
             client-secret: hN8Rie4aeelLrG3q9jgUm07gVsjdvVR8
             authorization-grant-type: authorization_code
-            redirect-uri: http://43.201.106.194/login/oauth2/code/kakao
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             scope:
               - account_email
             client-name: Kakao


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #76 

## 📝 작업 내용

팔로우한 상점 래플 더보기 구현 + 래플 둘러보기 + 내가 찜한 래플 더보기 구현 완료

래플 둘러보기는 응모 안된것들이 우선으로 나오고, 응모자순으로 나열하였고
팔로우한 상점 래플은 마감임박순으로 나열하였습니다. 
내가 찜한 래플 더보기는 찜한 순, 즉 찜의 createdAt순으로 나열하였습니다.

### 📸 스크린샷 (선택)

래플 둘러보기
<img width="975" alt="스크린샷 2025-01-28 오후 10 42 14" src="https://github.com/user-attachments/assets/814e0c04-df0b-49c1-ae64-16a8279fd289" />


## 💬 리뷰 요구사항(선택)
추가적으로 feat/71이 머지된 상황을 바탕으로 작업한거여서 feat/71 먼저 봐주시면 감사하겠습니다!
