### PR TITLE
✨[FEAT] #86: 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/general/SearchController.java
+++ b/src/main/java/com/example/demo/controller/general/SearchController.java
@@ -18,7 +18,7 @@ public class SearchController {
 
     @Operation(summary = "검색")
     @GetMapping("/raffles")
-    public ApiResponse<HomeRaffleListDTO> searchRaffles(@RequestParam String keyword, Authentication authentication){
+    public ApiResponse<HomeRaffleListDTO> searchRaffles(@RequestParam("keyword") String keyword, Authentication authentication){
         Long userId = null;
 
         // 로그인 한 경우

--- a/src/main/java/com/example/demo/controller/general/SearchController.java
+++ b/src/main/java/com/example/demo/controller/general/SearchController.java
@@ -3,6 +3,7 @@ package com.example.demo.controller.general;
 import com.example.demo.base.ApiResponse;
 import com.example.demo.base.status.SuccessStatus;
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
+import com.example.demo.domain.dto.Search.SearchResponseDTO;
 import com.example.demo.service.general.SearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +17,29 @@ public class SearchController {
 
     private final SearchService searchService;
 
+    @Operation(summary = "최근검색어와 인기검색어 조회")
+    @GetMapping("")
+    public ApiResponse<SearchResponseDTO> getRecentPopularSearch(Authentication authentication){
+
+        // 로그인 안한 경우, 최근 검색어와 인기검색어 없이 result에 null 반환
+        if(authentication == null || !authentication.isAuthenticated()){
+            return ApiResponse.of(SuccessStatus._OK, null);
+        }
+
+        // 로그인 한 경우, 유저아이디를 통해 최근 검색어와 인기검색어 조회
+        else{
+            Long userId = Long.parseLong(authentication.getName());
+            SearchResponseDTO result = searchService.getRecentPopularSearch(userId);
+            return ApiResponse.of(SuccessStatus._OK, result);
+        }
+
+    }
+
     @Operation(summary = "검색")
     @GetMapping("/raffles")
     public ApiResponse<HomeRaffleListDTO> searchRaffles(@RequestParam("keyword") String keyword, Authentication authentication){
+
+        // 로그인 안 했을 경우 유저아이디 null로 처리
         Long userId = null;
 
         // 로그인 한 경우

--- a/src/main/java/com/example/demo/controller/general/SearchController.java
+++ b/src/main/java/com/example/demo/controller/general/SearchController.java
@@ -1,0 +1,34 @@
+package com.example.demo.controller.general;
+
+import com.example.demo.base.ApiResponse;
+import com.example.demo.base.status.SuccessStatus;
+import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
+import com.example.demo.service.general.SearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/permit/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(summary = "검색")
+    @GetMapping("")
+    public ApiResponse<HomeRaffleListDTO> searchRaffles(@RequestParam String keyword, Authentication authentication){
+        Long userId = null;
+
+        // 로그인 한 경우
+        if(authentication != null && authentication.isAuthenticated()){
+            userId = Long.parseLong(authentication.getName());
+        }
+
+        HomeRaffleListDTO result = searchService.searchRaffles(keyword, userId);
+        return ApiResponse.of(SuccessStatus._OK, result);
+    }
+
+
+}

--- a/src/main/java/com/example/demo/controller/general/SearchController.java
+++ b/src/main/java/com/example/demo/controller/general/SearchController.java
@@ -17,7 +17,7 @@ public class SearchController {
     private final SearchService searchService;
 
     @Operation(summary = "검색")
-    @GetMapping("")
+    @GetMapping("/raffles")
     public ApiResponse<HomeRaffleListDTO> searchRaffles(@RequestParam String keyword, Authentication authentication){
         Long userId = null;
 

--- a/src/main/java/com/example/demo/domain/dto/Search/SearchResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Search/SearchResponseDTO.java
@@ -1,0 +1,20 @@
+package com.example.demo.domain.dto.Search;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchResponseDTO {
+
+    private List<String> recentSearch;
+    private List<String> popularSearch;
+
+
+}

--- a/src/main/java/com/example/demo/entity/SearchHistory.java
+++ b/src/main/java/com/example/demo/entity/SearchHistory.java
@@ -26,4 +26,15 @@ public class SearchHistory extends BaseEntity{
 
     private LocalDateTime searchedAt;
 
+    /**
+     * 연관관계 편의 메소드
+     */
+
+    // 검색기록을 최신화
+    public void updateSearchHistory(){
+        this.searchCount += 1;
+        this.searchedAt = LocalDateTime.now();
+    }
+
+
 }

--- a/src/main/java/com/example/demo/repository/RaffleRepository.java
+++ b/src/main/java/com/example/demo/repository/RaffleRepository.java
@@ -26,4 +26,7 @@ public interface RaffleRepository extends JpaRepository<Raffle, Long> {
     // 리뷰 수
     @Query("SELECT COUNT(r) FROM Review r WHERE r.user.id = :userId")
     int countReviewsByUserId(Long userId);
+
+    // 이름으로 래플 검색
+    List<Raffle> findAllByNameContaining(String keyword);
 }

--- a/src/main/java/com/example/demo/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/example/demo/repository/SearchHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.SearchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+    Optional<SearchHistory> findByKeywordAndUserId(String keyword, Long userId);
+}

--- a/src/main/java/com/example/demo/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/example/demo/repository/SearchHistoryRepository.java
@@ -3,8 +3,11 @@ package com.example.demo.repository;
 import com.example.demo.entity.SearchHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
     Optional<SearchHistory> findByKeywordAndUserId(String keyword, Long userId);
+    List<SearchHistory> findTop10ByUserIdOrderBySearchCountDesc(Long userId);
+    List<SearchHistory> findTop10ByUserIdOrderBySearchedAtDesc(Long userId);
 }

--- a/src/main/java/com/example/demo/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/UserRepository.java
@@ -28,6 +28,4 @@ public interface UserRepository extends JpaRepository<User,Long> {
 
     boolean existsByNickname(String nickname);
 
-    Optional<User> findByEmail(String email);
-
 }

--- a/src/main/java/com/example/demo/service/general/SearchService.java
+++ b/src/main/java/com/example/demo/service/general/SearchService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service.general;
+
+import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
+
+public interface SearchService {
+
+    HomeRaffleListDTO searchRaffles(String keyword, Long userId);
+
+}

--- a/src/main/java/com/example/demo/service/general/SearchService.java
+++ b/src/main/java/com/example/demo/service/general/SearchService.java
@@ -1,9 +1,11 @@
 package com.example.demo.service.general;
 
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
+import com.example.demo.domain.dto.Search.SearchResponseDTO;
 
 public interface SearchService {
 
     HomeRaffleListDTO searchRaffles(String keyword, Long userId);
 
+    SearchResponseDTO getRecentPopularSearch(Long userId);
 }

--- a/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/HomeServiceImpl.java
@@ -29,7 +29,6 @@ public class HomeServiceImpl implements HomeService {
     private final RaffleRepository raffleRepository;
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
-    private final LikeRepository likeRepository;
 
     @Override
     public HomeResponseDTO getHome() {
@@ -123,7 +122,7 @@ public class HomeServiceImpl implements HomeService {
         Category category = categoryRepository.findByName(categoryName)
                 .orElseThrow(() -> new CustomException(ErrorStatus.COMMON_WRONG_PARAMETER));
 
-        List<Raffle> raffles = raffleRepository.findByCategoryName(categoryName);
+        List<Raffle> raffles = raffleRepository.findByCategoryName(category.getName());
 
         // 카테고리별 조회 + 응모자순으로 래플 조회 (응모 안마감된것 우선)
         List<Raffle> rafflesSortedByApplyList = sortRafflesByApply(raffles);
@@ -278,7 +277,10 @@ public class HomeServiceImpl implements HomeService {
 
             // 로그인한 경우에만 likeStatus 조회
             if (user != null) {
-                likeStatus = likeRepository.findByUserIdAndRaffleId(user.getId(), raffle.getId()).isPresent();
+                List<Long> likedRaffleIds = user.getLikes().stream()
+                        .map(like -> like.getRaffle().getId())
+                        .toList();
+                likeStatus = likedRaffleIds.contains(raffle.getId());
             }
 
             HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, likeStatus);

--- a/src/main/java/com/example/demo/service/general/impl/SearchServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/SearchServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.domain.converter.HomeConverter;
 import com.example.demo.domain.dto.Home.HomeRaffleDTO;
 import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
+import com.example.demo.domain.dto.Search.SearchResponseDTO;
 import com.example.demo.entity.Raffle;
 import com.example.demo.entity.SearchHistory;
 import com.example.demo.entity.User;
@@ -67,6 +68,28 @@ public class SearchServiceImpl implements SearchService {
         return HomeRaffleListDTO.builder()
                 .raffles(result)
                 .build();
+    }
+
+    @Override
+    public SearchResponseDTO getRecentPopularSearch(Long userId) {
+
+        List<String> popularSearchResult = new ArrayList<>();
+        List<String> recentSearchResult = new ArrayList<>();
+
+        List<SearchHistory> popularSearch = searchHistoryRepository.findTop10ByUserIdOrderBySearchCountDesc(userId);
+        for (SearchHistory searchHistory : popularSearch) {
+            popularSearchResult.add(searchHistory.getKeyword());
+        }
+        List<SearchHistory> recentSearch = searchHistoryRepository.findTop10ByUserIdOrderBySearchedAtDesc(userId);
+        for (SearchHistory searchHistory : recentSearch) {
+            recentSearchResult.add(searchHistory.getKeyword());
+        }
+
+        return SearchResponseDTO.builder()
+                .popularSearch(popularSearchResult)
+                .recentSearch(recentSearchResult)
+                .build();
+
     }
 
 

--- a/src/main/java/com/example/demo/service/general/impl/SearchServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/SearchServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.demo.service.general.impl;
+
+import com.example.demo.base.code.exception.CustomException;
+import com.example.demo.base.status.ErrorStatus;
+import com.example.demo.domain.converter.HomeConverter;
+import com.example.demo.domain.dto.Home.HomeRaffleDTO;
+import com.example.demo.domain.dto.Home.HomeRaffleListDTO;
+import com.example.demo.entity.Raffle;
+import com.example.demo.entity.SearchHistory;
+import com.example.demo.entity.User;
+import com.example.demo.repository.RaffleRepository;
+import com.example.demo.repository.SearchHistoryRepository;
+import com.example.demo.repository.UserRepository;
+import com.example.demo.service.general.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SearchServiceImpl implements SearchService {
+
+    private final RaffleRepository raffleRepository;
+    private final UserRepository userRepository;
+    private final SearchHistoryRepository searchHistoryRepository;
+
+    @Override
+    @Transactional
+    public HomeRaffleListDTO searchRaffles(String keyword, Long userId) {
+
+        // 검색 결과에 따른 List 반환
+        List<Raffle> raffles = raffleRepository.findAllByNameContaining(keyword);
+
+        // 로그인 안한 회원인 경우 user를 null로 처리
+        User user = null;
+
+        // 로그인 한 회원인 경우 user 불러오기 + 해당 유저의 검색기록 최신화 (이미 존재했던 검색어면 searchCount, searchedAt 최신화)
+        if(userId != null){
+            user = userRepository.findById(userId)
+                    .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+            Optional<SearchHistory> searchHistory = searchHistoryRepository.findByKeywordAndUserId(keyword, user.getId());
+            if(searchHistory.isEmpty()){
+                SearchHistory newSearchHistory = SearchHistory.builder()
+                        .user(user)
+                        .keyword(keyword)
+                        .searchCount(1)
+                        .searchedAt(LocalDateTime.now())
+                        .build();
+
+                searchHistoryRepository.save(newSearchHistory);
+            }
+            else{
+                SearchHistory prevSearchHistory = searchHistory.get();
+                prevSearchHistory.updateSearchHistory();
+            }
+        }
+
+        List<HomeRaffleDTO> result = convertToHomeRaffleDTOList(raffles, user);
+
+        return HomeRaffleListDTO.builder()
+                .raffles(result)
+                .build();
+    }
+
+
+    /**
+     * 사용하는 메소드 분리
+     * */
+
+    private List<HomeRaffleDTO> convertToHomeRaffleDTOList(List<Raffle> raffles, User user) {
+        List<HomeRaffleDTO> dtoList = new ArrayList<>();
+
+        for (Raffle raffle : raffles) {
+            boolean likeStatus = false;
+
+            // 로그인한 경우에만 likeStatus 조회
+            if (user != null) {
+                List<Long> likedRaffleIds = user.getLikes().stream()
+                        .map(like -> like.getRaffle().getId())
+                        .toList();
+                likeStatus = likedRaffleIds.contains(raffle.getId());
+            }
+
+            HomeRaffleDTO raffleDTO = HomeConverter.toHomeRaffleDTO(raffle, likeStatus);
+            dtoList.add(raffleDTO);
+        }
+
+        return dtoList;
+    }
+
+}


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #86 

## 📝 작업 내용

키워드 검색을 통해 래플을 검색하는 기능을 구현하였습니다.
추가적으로, 로그인 한 회원은 검색시 검색어가 생성되는 기능을 구현하였습니다. 그리고 기존에 존재하는 검색어로 검색한 경우에는
searchCount와 searchAt을 업데이트 하는 로직을 구현하였습니다. 

추가적으로 최근 검색어와 인기 검색어 조회 기능 까지 구현하였습니다.

### 📸 스크린샷 (선택)

에라고 검색한 결과:
<img width="450" alt="스크린샷 2025-01-30 오전 12 02 04" src="https://github.com/user-attachments/assets/80666173-270a-41ac-90a6-941d07dc8092" />

검색어가 검색될때마다 검색횟수가 1씩 증가하고, searchedAt이 업데이트됨
<img width="833" alt="스크린샷 2025-01-30 오전 12 02 52" src="https://github.com/user-attachments/assets/50399cc6-8f1d-4b10-bf9d-500535257c8c" />

최근 검색어와 인기검색어 조회 결과:
<img width="571" alt="스크린샷 2025-01-30 오전 11 01 39" src="https://github.com/user-attachments/assets/787ea790-8786-409c-a30c-04815b4f6219" />



## 💬 리뷰 요구사항(선택)
이전 Home에 사용한 로직을 사용하는 과정에서 조금 수정한 부분이 있는데, 이부분도 봐주시면 감사하겠습니다!
