### PR TITLE
✨[FEAT] #85: delivery Job 설정

### DIFF
--- a/src/main/java/com/example/demo/jobs/AddressJob.java
+++ b/src/main/java/com/example/demo/jobs/AddressJob.java
@@ -1,0 +1,43 @@
+package com.example.demo.jobs;
+
+import com.example.demo.base.code.exception.CustomException;
+import com.example.demo.base.status.ErrorStatus;
+import com.example.demo.entity.Delivery;
+import com.example.demo.entity.base.enums.DeliveryStatus;
+import com.example.demo.repository.DeliveryRepository;
+import com.example.demo.service.general.DeliverySchedulerService;
+import com.example.demo.service.general.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.SchedulerException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AddressJob implements Job {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DeliverySchedulerService deliverySchedulerService;
+    private final EmailService emailService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+
+        Delivery delivery = deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
+
+        delivery.setDeliveryStatus(DeliveryStatus.ADDRESS_EXPIRED);
+        deliveryRepository.save(delivery);
+
+        try {
+            deliverySchedulerService.scheduleDeliveryJob(delivery);
+        } catch (SchedulerException e) {
+            throw new JobExecutionException(e, false);
+        }
+
+        emailService.sendAddressExpiredEmail(delivery);
+    }
+}

--- a/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
@@ -1,0 +1,45 @@
+package com.example.demo.jobs;
+
+import com.example.demo.base.code.exception.CustomException;
+import com.example.demo.base.status.ErrorStatus;
+import com.example.demo.entity.Apply;
+import com.example.demo.entity.Delivery;
+import com.example.demo.entity.Raffle;
+import com.example.demo.entity.base.enums.DeliveryStatus;
+import com.example.demo.repository.DeliveryRepository;
+import com.example.demo.service.general.DrawService;
+import com.example.demo.service.general.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ExtendAddressJob implements Job {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DrawService drawService;
+    private final EmailService emailService;
+
+    @Override
+    public void execute(JobExecutionContext context) {
+
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+
+        Delivery delivery = deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
+
+        delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
+        deliveryRepository.save(delivery);
+
+        Raffle raffle = delivery.getRaffle();
+        List<Apply> applyList = raffle.getApplyList();
+        drawService.cancel(raffle, applyList);
+
+//        emailService.sendWinnerCancelEmail(delivery);
+        emailService.sendOwnerCancelEmail(raffle);
+    }
+}

--- a/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
@@ -1,0 +1,48 @@
+package com.example.demo.jobs;
+
+import com.example.demo.base.code.exception.CustomException;
+import com.example.demo.base.status.ErrorStatus;
+import com.example.demo.entity.Apply;
+import com.example.demo.entity.Delivery;
+import com.example.demo.entity.Raffle;
+import com.example.demo.entity.base.enums.DeliveryStatus;
+import com.example.demo.repository.DeliveryRepository;
+import com.example.demo.service.general.DrawService;
+import com.example.demo.service.general.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ExtendShippingJob implements Job {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DrawService drawService;
+    private final EmailService emailService;
+
+    @Override
+    public void execute(JobExecutionContext context) {
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+
+        Delivery delivery = deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
+
+        delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
+        deliveryRepository.save(delivery);
+
+        Raffle raffle = delivery.getRaffle();
+        List<Apply> applyList = raffle.getApplyList();
+        drawService.cancel(raffle, applyList);
+
+//        emailService.sendWinnerCancelEmail(delivery);
+        emailService.sendOwnerCancelEmail(raffle);
+
+        // Todo: 배송비 환불
+
+    }
+}

--- a/src/main/java/com/example/demo/jobs/RaffleStartJob.java
+++ b/src/main/java/com/example/demo/jobs/RaffleStartJob.java
@@ -8,7 +8,6 @@ import com.example.demo.repository.RaffleRepository;
 import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/example/demo/jobs/ShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ShippingJob.java
@@ -1,0 +1,45 @@
+package com.example.demo.jobs;
+
+import com.example.demo.base.code.exception.CustomException;
+import com.example.demo.base.status.ErrorStatus;
+import com.example.demo.entity.Delivery;
+import com.example.demo.entity.base.enums.DeliveryStatus;
+import com.example.demo.repository.DeliveryRepository;
+import com.example.demo.service.general.DeliverySchedulerService;
+import com.example.demo.service.general.DeliveryService;
+import com.example.demo.service.general.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.SchedulerException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ShippingJob implements Job {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DeliverySchedulerService deliverySchedulerService;
+    private final EmailService emailService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+
+        Delivery delivery = deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
+
+        delivery.setDeliveryStatus(DeliveryStatus.SHIPPING_EXPIRED);
+        deliveryRepository.save(delivery);
+
+        try {
+            deliverySchedulerService.scheduleDeliveryJob(delivery);
+        } catch (SchedulerException e) {
+            throw new JobExecutionException(e, false);
+        }
+
+        emailService.sendWinnerShippingExpiredEmail(delivery);
+
+    }
+}

--- a/src/main/java/com/example/demo/service/general/DeliverySchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/DeliverySchedulerService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service.general;
+
+import com.example.demo.entity.Delivery;
+import org.quartz.SchedulerException;
+
+public interface DeliverySchedulerService {
+
+    void scheduleDeliveryJob(Delivery delivery) throws SchedulerException;
+}

--- a/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service.general;
+
+import com.example.demo.entity.Raffle;
+import org.quartz.SchedulerException;
+
+public interface DrawSchedulerService {
+
+    void scheduleDrawJob(Raffle raffle) throws SchedulerException;
+}

--- a/src/main/java/com/example/demo/service/general/EmailService.java
+++ b/src/main/java/com/example/demo/service/general/EmailService.java
@@ -7,4 +7,10 @@ import com.example.demo.entity.User;
 public interface EmailService {
 
     public void sendEmail(Delivery delivery);
+
+    void sendAddressExpiredEmail(Delivery delivery);
+
+    void sendOwnerCancelEmail(Raffle raffle);
+
+    void sendWinnerShippingExpiredEmail(Delivery delivery);
 }

--- a/src/main/java/com/example/demo/service/general/RaffleSchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/RaffleSchedulerService.java
@@ -4,5 +4,5 @@ import com.example.demo.entity.Raffle;
 
 public interface RaffleSchedulerService {
 
-    public void scheduleRaffleJob(Raffle raffle, boolean isStart);
+    void scheduleRaffleJob(Raffle raffle, boolean isStart);
 }

--- a/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
@@ -1,0 +1,96 @@
+package com.example.demo.service.general.impl;
+
+import com.example.demo.base.Constants;
+import com.example.demo.entity.Delivery;
+import com.example.demo.entity.base.enums.DeliveryStatus;
+import com.example.demo.jobs.*;
+import com.example.demo.service.general.DeliverySchedulerService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
+
+    private final Scheduler scheduler;
+
+    @Override
+    public void scheduleDeliveryJob(Delivery delivery) throws SchedulerException {
+        if (!scheduler.isStarted()) {
+            scheduler.start();
+        }
+
+        JobDetail jobDetail = null;
+        Trigger trigger = null;
+
+        DeliveryStatus deliveryStatus = delivery.getDeliveryStatus();
+        switch (deliveryStatus) {
+            case WAITING_ADDRESS:
+                jobDetail = buildAddressJobDetail(delivery);
+                trigger = buildJobTrigger(delivery.getAddressDeadline());
+                break;
+            case READY:
+                jobDetail = buildShippingJobDetail(delivery);
+                trigger = buildJobTrigger(delivery.getShippingDeadline());
+                break;
+            case ADDRESS_EXPIRED:
+                jobDetail = buildExtendAddressJobDetail(delivery);
+                trigger = buildJobTrigger(delivery.getAddressDeadline().plusHours(Constants.WAIT));
+                break;
+            case SHIPPING_EXPIRED:
+                jobDetail = buildExtendShippingJobDetail(delivery);
+                trigger = buildJobTrigger(delivery.getShippingDeadline().plusHours(Constants.WAIT));
+                break;
+        }
+
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+
+    private JobDetail buildAddressJobDetail(Delivery delivery) {
+        return JobBuilder.newJob(AddressJob.class)
+                .withIdentity("Delivery_" + delivery.getId() + "_WAITING_ADDRESS")
+                .usingJobData("deliveryId", delivery.getId())
+                .storeDurably()
+                .build();
+    }
+
+    private JobDetail buildShippingJobDetail(Delivery delivery) {
+        return JobBuilder.newJob(ShippingJob.class)
+                .withIdentity("Delivery_" + delivery.getId() + "_READY")
+                .usingJobData("deliveryId", delivery.getId())
+                .storeDurably()
+                .build();
+    }
+
+    private JobDetail buildExtendAddressJobDetail(Delivery delivery) {
+        return JobBuilder.newJob(ExtendAddressJob.class)
+                .withIdentity("Delivery_" + delivery.getId() + "_ADDRESS_EXPIRED")
+                .usingJobData("deliveryId", delivery.getId())
+                .storeDurably()
+                .build();
+    }
+
+    private JobDetail buildExtendShippingJobDetail(Delivery delivery) {
+        return JobBuilder.newJob(ExtendShippingJob.class)
+                .withIdentity("Delivery_" + delivery.getId() + "_SHIPPING_EXPIRED")
+                .usingJobData("deliveryId", delivery.getId())
+                .storeDurably()
+                .build();
+    }
+
+    private Trigger buildJobTrigger(LocalDateTime time) {
+        LocalDateTime adjustedTime = time.withSecond(0).withNano(0);
+        Date startDate = Date.from(adjustedTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        return TriggerBuilder.newTrigger()
+                .startAt(startDate)
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withMisfireHandlingInstructionFireNow())
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/service/general/impl/DrawSchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawSchedulerServiceImpl.java
@@ -1,0 +1,51 @@
+package com.example.demo.service.general.impl;
+
+import com.example.demo.base.Constants;
+import com.example.demo.entity.Raffle;
+import com.example.demo.jobs.ExtendShippingJob;
+import com.example.demo.service.general.DrawSchedulerService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class DrawSchedulerServiceImpl implements DrawSchedulerService {
+
+    private final Scheduler scheduler;
+
+    @Override
+    public void scheduleDrawJob(Raffle raffle) throws SchedulerException {
+        if (!scheduler.isStarted()) {
+            scheduler.start();
+        }
+
+        JobDetail jobDetail = buildDrawJobDetail(raffle);
+        Trigger trigger = buildJobTrigger(raffle.getEndAt().plusHours(Constants.WAIT));
+
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+
+    private JobDetail buildDrawJobDetail(Raffle raffle) {
+        return JobBuilder.newJob(ExtendShippingJob.class)
+                .withIdentity("Raffle_" + raffle.getId() + "_UNFULFILLED")
+                .usingJobData("raffleId", raffle.getId())
+                .storeDurably()
+                .build();
+    }
+
+    private Trigger buildJobTrigger(LocalDateTime time) {
+        LocalDateTime adjustedTime = time.withSecond(0).withNano(0);
+        Date startDate = Date.from(adjustedTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        return TriggerBuilder.newTrigger()
+                .startAt(startDate)
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withMisfireHandlingInstructionFireNow())
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.general.impl;
 
+import com.example.demo.base.Constants;
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.entity.Delivery;
@@ -60,6 +61,98 @@ public class EmailServiceImpl implements EmailService {
             context.setVariable("fromEmail", fromEmail);
 
             String body = templateEngine.process("EmailTemplate.html", context);
+            helper.setText(body, true);
+
+            mailSender.send(helper.getMimeMessage());
+
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorStatus.DRAW_EMAIL_FAILED);
+        }
+    }
+
+    @Override
+    public void sendAddressExpiredEmail(Delivery delivery) {
+        User user = delivery.getUser();
+        Raffle raffle = delivery.getRaffle();
+
+        try {
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(user.getEmail());
+            helper.setFrom(fromEmail);
+
+            String subject = "[장마당] " + raffle.getName() + " 배송지 입력 기한 만료 안내";
+            helper.setSubject(subject);
+
+            Context context = new Context();
+            context.setVariable("userName", user.getNickname());
+            context.setVariable("url", String.format(Constants.DELIVERY_OWNER_URL, delivery.getId()));
+            context.setVariable("fromEmail", fromEmail);
+
+            String body = templateEngine.process("OwnerAddressExpiredEmail.html", context);
+            helper.setText(body, true);
+
+            mailSender.send(helper.getMimeMessage());
+
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorStatus.DRAW_EMAIL_FAILED);
+        }
+    }
+
+    @Override
+    public void sendOwnerCancelEmail(Raffle raffle) {
+        User user = raffle.getUser();
+
+        try {
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(user.getEmail());
+            helper.setFrom(fromEmail);
+
+            String subject = "[장마당] " + raffle.getName() + " 래플 종료 안내";
+            helper.setSubject(subject);
+
+            Context context = new Context();
+            context.setVariable("userName", user.getNickname());
+            context.setVariable("raffleName", raffle.getName());
+            context.setVariable("fromEmail", fromEmail);
+
+            String body = templateEngine.process("OwnerCancelEmail.html", context);
+            helper.setText(body, true);
+
+            mailSender.send(helper.getMimeMessage());
+
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorStatus.DRAW_EMAIL_FAILED);
+        }
+    }
+
+    @Override
+    public void sendWinnerShippingExpiredEmail(Delivery delivery) {
+        User user = delivery.getWinner();
+        Raffle raffle = delivery.getRaffle();
+
+        try {
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(user.getEmail());
+            helper.setFrom(fromEmail);
+
+            String subject = "[장마당] " + raffle.getName() + " 운송장 입력 기한 만료 안내";
+            helper.setSubject(subject);
+
+            Context context = new Context();
+            context.setVariable("userName", user.getNickname());
+//            context.setVariable("url", String.format(Constants.DELIVERY_WINNER_URL, delivery.getId()));
+            context.setVariable("fromEmail", fromEmail);
+
+            String body = templateEngine.process("WinnerShippingExpiredEmail.html", context);
             helper.setText(body, true);
 
             mailSender.send(helper.getMimeMessage());

--- a/src/main/java/com/example/demo/service/general/impl/RaffleSchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/RaffleSchedulerServiceImpl.java
@@ -18,6 +18,7 @@ public class RaffleSchedulerServiceImpl implements RaffleSchedulerService {
 
     private final Scheduler scheduler;
 
+    @Override
     public void scheduleRaffleJob(Raffle raffle, boolean isStart) {
         try {
 

--- a/src/main/resources/templates/OwnerAddressExpiredEmail.html
+++ b/src/main/resources/templates/OwnerAddressExpiredEmail.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>배송지 입력 및 결제 기한 만료 안내</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            width: 100%;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .header h1 {
+            color: #4CAF50;
+            font-size: 24px;
+        }
+        .content {
+            margin-bottom: 20px;
+        }
+        .content p {
+            font-size: 16px;
+            margin: 10px 0;
+        }
+        .content .highlight {
+            font-weight: bold;
+            color: #e74c3c;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 20px;
+            font-size: 16px;
+            color: #fff;
+            background-color: #4CAF50;
+            text-align: center;
+            text-decoration: none;
+            border-radius: 5px;
+            margin-top: 20px;
+        }
+        .footer {
+            text-align: center;
+            font-size: 14px;
+            color: #999;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="header">
+        <h1>배송지 입력 기한 만료 안내</h1>
+    </div>
+    <div class="content">
+        <p>안녕하세요, <b th:text="${userName}"></b>님!</p>
+        <p>먼저, 장마당 래플 서비스에 참여해 주셔서 감사합니다.</p>
+        <p>하지만, 당첨자에게 주어진 배송지 입력 및 배송비 결제 기한이 만료되었습니다. 따라서, 배송지 입력과 결제를 완료하기 위한 24시간 연장 기회가 제공됩니다.</p>
+        <p>기한 내에 연장하지 않으시면 해당 래플은 취소되며, 응모된 티켓은 <span class="highlight">모든 응모자에게 반환</span>됩니다.</p>
+
+        <p>### <span class="highlight">아래 URL에 접속해 연장 여부를 선택해주세요</span></p>
+        <a th:href="@{${url}}" class="button">24시간 연장 선택</a>
+
+        <p>※ 24시간 연장 기한이 지나면 자동으로 응모한 티켓이 반환되며 래플은 취소됩니다.</p>
+
+        <p><span class="highlight">주의사항</span><br>
+            - 연장 기한이 지나면 더 이상의 연장은 불가하며, 해당 래플은 취소 처리됩니다.<br>
+            - 기한 내에 연장을 선택하지 않거나 기한이 만료된 경우, 래플은 자동으로 취소 처리됩니다.<br>
+            - 또한, 재추첨을 진행하거나, 강제로 종료시킬 수도 있습니다.<br>
+        </p>
+
+        <p>다시 한 번 장마당 서비스를 이용해 주셔서 감사드리며, 향후 더 좋은 기회로 찾아뵙겠습니다.</p>
+
+        <p>감사합니다.</p>
+
+    </div>
+
+    <div class="footer">
+        <p>본 메일은 발신 전용입니다. 문의사항이 있으시면 <a th:href="'mailto:' + ${fromEmail}">[고객센터 이메일]</a>로 연락 부탁드립니다.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/OwnerCancelEmail.html
+++ b/src/main/resources/templates/OwnerCancelEmail.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>래플 취소 및 티켓 반환 안내</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            width: 100%;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .header h1 {
+            color: #4CAF50;
+            font-size: 24px;
+        }
+        .content {
+            margin-bottom: 20px;
+        }
+        .content p {
+            font-size: 16px;
+            margin: 10px 0;
+        }
+        .content .highlight {
+            font-weight: bold;
+            color: #e74c3c;
+        }
+        .footer {
+            text-align: center;
+            font-size: 14px;
+            color: #999;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="header">
+        <h1>래플 취소 안내</h1>
+    </div>
+    <div class="content">
+        <p>안녕하세요, <b th:text="${userName}"></b>님!</p>
+        <p>먼저, 장마당 래플 서비스에 참여해 주셔서 감사합니다.</p>
+        <p>안타깝게도, <b th:text="${raffleName}"> </b> 래플이 취소되었습니다.</p>
+        <p>이로 인해, 응모한 모든 티켓은 자동으로 반환되었습니다.</p>
+
+        <p>### <span class="highlight">응모한 티켓이 반환되었음을 안내드립니다</span></p>
+
+        <p>해당 래플에 대한 추가적인 정보나 궁금한 점이 있으시면 언제든지 고객센터로 문의해 주세요.</p>
+
+        <p>다시 한 번 장마당 서비스를 이용해 주셔서 감사드리며, 향후 더 좋은 기회로 찾아뵙겠습니다.</p>
+
+        <p>감사합니다.</p>
+
+    </div>
+
+    <div class="footer">
+        <p>본 메일은 발신 전용입니다. 문의사항이 있으시면 <a th:href="'mailto:' + ${fromEmail}">[고객센터 이메일]</a>로 연락 부탁드립니다.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/WinnerShippingExpiredEmail.html
+++ b/src/main/resources/templates/WinnerShippingExpiredEmail.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>배송지 입력 및 결제 기한 만료 안내</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            width: 100%;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .header h1 {
+            color: #4CAF50;
+            font-size: 24px;
+        }
+        .content {
+            margin-bottom: 20px;
+        }
+        .content p {
+            font-size: 16px;
+            margin: 10px 0;
+        }
+        .content .highlight {
+            font-weight: bold;
+            color: #e74c3c;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 20px;
+            font-size: 16px;
+            color: #fff;
+            background-color: #4CAF50;
+            text-align: center;
+            text-decoration: none;
+            border-radius: 5px;
+            margin-top: 20px;
+        }
+        .footer {
+            text-align: center;
+            font-size: 14px;
+            color: #999;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="header">
+        <h1>운송장 입력 기한 만료 안내</h1>
+    </div>
+    <div class="content">
+        <p>안녕하세요, <b th:text="${userName}"></b>님!</p>
+        <p>먼저, 장마당 래플 서비스에 참여해 주셔서 감사합니다.</p>
+        <p>하지만, 개최자에게 주어진 운송장 입력 기한이 만료되었습니다. 따라서, 운송장 입력을 완료하기 위한 24시간 연장 기회가 제공됩니다.</p>
+        <p>기한 내에 연장하지 않으시면 해당 래플은 취소되며, 응모된 티켓은 <span class="highlight">모든 응모자에게 반환</span>됩니다.</p>
+
+        <p>### <span class="highlight">아래 URL에 접속해 연장 여부를 선택해주세요</span></p>
+        <a th:href="@{${url}}" class="button">24시간 연장 선택</a>
+
+        <p>※ 24시간 연장 기한이 지나면 자동으로 응모한 티켓이 반환되며 래플은 취소됩니다.</p>
+
+        <p><span class="highlight">주의사항</span><br>
+            - 연장 기한이 지나면 더 이상의 연장은 불가하며, 해당 래플은 취소 처리됩니다.<br>
+            - 기한 내에 연장을 선택하지 않거나 기한이 만료된 경우, 래플은 자동으로 취소 처리됩니다.<br>
+            - 또한, 결제된 배송비는 자동 환불 처리됩니다. <br>
+        </p>
+
+        <p>다시 한 번 장마당 서비스를 이용해 주셔서 감사드리며, 향후 더 좋은 기회로 찾아뵙겠습니다.</p>
+
+        <p>감사합니다.</p>
+
+    </div>
+
+    <div class="footer">
+        <p>본 메일은 발신 전용입니다. 문의사항이 있으시면 <a th:href="'mailto:' + ${fromEmail}">[고객센터 이메일]</a>로 연락 부탁드립니다.</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #85 

## 📝 작업 내용

추첨 완료된 래플
배송지 입력 대기, 배송지 입력 기한 연장 대기, 운송장 입력 대기, 운송장 입력 연장 대기

미추첨된 래플
수동 추첨 대기

각 작업을 담당하는 스케쥴러 Job을 생성하였습니다.

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
관련 코드 PR이 많은 상태라 Job 정의만 하고 서비스 로직에서 호출하는 부분은 구현하지 않았습니다. 추후 수정할 예정이니 설계된 Job 로직에 문제가 없는지 위주로 확인 부탁드립니다.
