### PR TITLE
✨[FEAT] #103: Job 연결

### DIFF
--- a/src/main/java/com/example/demo/base/status/ErrorStatus.java
+++ b/src/main/java/com/example/demo/base/status/ErrorStatus.java
@@ -73,7 +73,10 @@ public enum ErrorStatus implements BaseErrorCode {
     JOB_EXECUTION_FAILED(HttpStatus.BAD_REQUEST, "JOB_4001", "Job 실행에 실패했습니다."),
     JOB_STORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JOB_5001", "Job 저장에 실패했습니다."),
     JOB_UNKNOWN(HttpStatus.INTERNAL_SERVER_ERROR, "JOB_5002", "알 수 없는 Job 에러가 발생했습니다."),
-//    JOB_INTERRUPT(HttpStatus.SERVICE_UNAVAILABLE, "JOB_5031", "Job 인터럽트가 발생했습니다."),
+    JOB_NOT_FOUND(HttpStatus.BAD_REQUEST, "JOB_4002", "Job을 찾을 수 없습니다."),
+    JOB_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JOB_5003", "Job 취소에 실패했습니다."),
+    INVALID_DELIVERY_STATUS(HttpStatus.BAD_REQUEST, "JOB_4003", "Job 설정 가능한 배송 상태가 아닙니다."),
+    JOB_CREATION_FAILED(HttpStatus.BAD_REQUEST, "JOB_4004", "Job 생성에 실패했습니다."),
 
     // 13. Huiju - 당첨자 추첨 관련 에러
     DRAW_EMPTY(HttpStatus.BAD_REQUEST, "DRAW_4001", "응모한 사용자가 없습니다."),

--- a/src/main/java/com/example/demo/entity/Delivery.java
+++ b/src/main/java/com/example/demo/entity/Delivery.java
@@ -55,31 +55,27 @@ public class Delivery extends BaseEntity {
 
     public void setAddressDeadline() {
         this.addressDeadline = LocalDateTime.now()
-//                .plusHours(Constants.ADDRESS_DEADLINE)
-                .plusMinutes(1)
+                .plusHours(Constants.ADDRESS_DEADLINE)
                 .withSecond(0)
                 .withNano(0);
     }
 
     public void setShippingDeadline() {
         this.shippingDeadline = LocalDateTime.now()
-//                .plusHours(Constants.SHIPPING_DEADLINE)
-                .plusMinutes(1)
+                .plusHours(Constants.SHIPPING_DEADLINE)
                 .withSecond(0)
                 .withNano(0);
     }
 
     public void extendAddressDeadline() {
         this.deliveryStatus = DeliveryStatus.WAITING_ADDRESS;
-//        this.addressDeadline = this.addressDeadline.plusHours(Constants.WAIT);
-        this.addressDeadline = LocalDateTime.now().plusMinutes(1).withSecond(0).withNano(0);
+        this.addressDeadline = this.addressDeadline.plusHours(Constants.WAIT);
         this.isAddressExtended = true;
     }
 
     public void extendShippingDeadline() {
         this.deliveryStatus = DeliveryStatus.READY;
-//        this.shippingDeadline = this.shippingDeadline.plusHours(Constants.WAIT);
-        this.shippingDeadline = LocalDateTime.now().plusMinutes(1).withSecond(0).withNano(0);
+        this.shippingDeadline = this.shippingDeadline.plusHours(Constants.WAIT);
         this.isShippingExtended = true;
     }
 

--- a/src/main/java/com/example/demo/entity/Delivery.java
+++ b/src/main/java/com/example/demo/entity/Delivery.java
@@ -55,27 +55,31 @@ public class Delivery extends BaseEntity {
 
     public void setAddressDeadline() {
         this.addressDeadline = LocalDateTime.now()
-                .plusHours(Constants.ADDRESS_DEADLINE)
+//                .plusHours(Constants.ADDRESS_DEADLINE)
+                .plusMinutes(1)
                 .withSecond(0)
                 .withNano(0);
     }
 
     public void setShippingDeadline() {
         this.shippingDeadline = LocalDateTime.now()
-                .plusHours(Constants.SHIPPING_DEADLINE)
+//                .plusHours(Constants.SHIPPING_DEADLINE)
+                .plusMinutes(1)
                 .withSecond(0)
                 .withNano(0);
     }
 
     public void extendAddressDeadline() {
         this.deliveryStatus = DeliveryStatus.WAITING_ADDRESS;
-        this.addressDeadline = this.addressDeadline.plusHours(Constants.WAIT);
+//        this.addressDeadline = this.addressDeadline.plusHours(Constants.WAIT);
+        this.addressDeadline = LocalDateTime.now().plusMinutes(1).withSecond(0).withNano(0);
         this.isAddressExtended = true;
     }
 
     public void extendShippingDeadline() {
         this.deliveryStatus = DeliveryStatus.READY;
-        this.shippingDeadline = this.shippingDeadline.plusHours(Constants.WAIT);
+//        this.shippingDeadline = this.shippingDeadline.plusHours(Constants.WAIT);
+        this.shippingDeadline = LocalDateTime.now().plusMinutes(1).withSecond(0).withNano(0);
         this.isShippingExtended = true;
     }
 

--- a/src/main/java/com/example/demo/jobs/AddressJob.java
+++ b/src/main/java/com/example/demo/jobs/AddressJob.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -24,8 +25,9 @@ public class AddressJob implements Job {
     private final DrawService drawService;
 
     @Override
+    @Transactional
     public void execute(JobExecutionContext context){
-        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/AddressJob.java
+++ b/src/main/java/com/example/demo/jobs/AddressJob.java
@@ -27,7 +27,7 @@ public class AddressJob implements Job {
     @Override
     @Transactional
     public void execute(JobExecutionContext context){
-        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/AddressJob.java
+++ b/src/main/java/com/example/demo/jobs/AddressJob.java
@@ -3,15 +3,15 @@ package com.example.demo.jobs;
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.entity.Delivery;
+import com.example.demo.entity.Raffle;
 import com.example.demo.entity.base.enums.DeliveryStatus;
 import com.example.demo.repository.DeliveryRepository;
 import com.example.demo.service.general.DeliverySchedulerService;
+import com.example.demo.service.general.DrawService;
 import com.example.demo.service.general.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.SchedulerException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,23 +21,30 @@ public class AddressJob implements Job {
     private final DeliveryRepository deliveryRepository;
     private final DeliverySchedulerService deliverySchedulerService;
     private final EmailService emailService;
+    private final DrawService drawService;
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
+    public void execute(JobExecutionContext context){
         Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
 
-        delivery.setDeliveryStatus(DeliveryStatus.ADDRESS_EXPIRED);
-        deliveryRepository.save(delivery);
+        if (!delivery.isAddressExtended()) {
+            delivery.setDeliveryStatus(DeliveryStatus.ADDRESS_EXPIRED);
+            deliveryRepository.save(delivery);
 
-        try {
             deliverySchedulerService.scheduleDeliveryJob(delivery);
-        } catch (SchedulerException e) {
-            throw new JobExecutionException(e, false);
-        }
+            emailService.sendOwnerAddressExpiredEmail(delivery);
+        } else {
+            delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
+            deliveryRepository.save(delivery);
 
-        emailService.sendAddressExpiredEmail(delivery);
+            Raffle raffle = delivery.getRaffle();
+            drawService.cancel(raffle);
+
+            emailService.sendWinnerCancelEmail(delivery);
+            emailService.sendOwnerCancelEmail(raffle);
+        }
     }
 }

--- a/src/main/java/com/example/demo/jobs/DrawJob.java
+++ b/src/main/java/com/example/demo/jobs/DrawJob.java
@@ -2,11 +2,7 @@ package com.example.demo.jobs;
 
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
-import com.example.demo.entity.Apply;
-import com.example.demo.entity.Delivery;
 import com.example.demo.entity.Raffle;
-import com.example.demo.entity.base.enums.DeliveryStatus;
-import com.example.demo.entity.base.enums.RaffleStatus;
 import com.example.demo.repository.RaffleRepository;
 import com.example.demo.service.general.DrawService;
 import com.example.demo.service.general.EmailService;
@@ -14,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -32,8 +26,7 @@ public class DrawJob implements Job {
         Raffle raffle = raffleRepository.findById(raffleId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.RAFFLE_NOT_FOUND));
 
-        List<Apply> applyList = raffle.getApplyList();
-        drawService.cancel(raffle, applyList);
+        drawService.cancel(raffle);
 
         emailService.sendOwnerCancelEmail(raffle);
     }

--- a/src/main/java/com/example/demo/jobs/DrawJob.java
+++ b/src/main/java/com/example/demo/jobs/DrawJob.java
@@ -23,7 +23,7 @@ public class DrawJob implements Job {
     @Override
     @Transactional
     public void execute(JobExecutionContext context) {
-        Long raffleId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("raffleId"));
+        Long raffleId = context.getJobDetail().getJobDataMap().getLong("raffleId");
 
         Raffle raffle = raffleRepository.findById(raffleId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.RAFFLE_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/DrawJob.java
+++ b/src/main/java/com/example/demo/jobs/DrawJob.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -20,8 +21,9 @@ public class DrawJob implements Job {
     private final EmailService emailService;
 
     @Override
+    @Transactional
     public void execute(JobExecutionContext context) {
-        Long raffleId = context.getJobDetail().getJobDataMap().getLong("raffleId");
+        Long raffleId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("raffleId"));
 
         Raffle raffle = raffleRepository.findById(raffleId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.RAFFLE_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -22,9 +23,9 @@ public class ExtendAddressJob implements Job {
     private final EmailService emailService;
 
     @Override
+    @Transactional
     public void execute(JobExecutionContext context) {
-
-        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
@@ -25,7 +25,7 @@ public class ExtendAddressJob implements Job {
     @Override
     @Transactional
     public void execute(JobExecutionContext context) {
-        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendAddressJob.java
@@ -2,7 +2,6 @@ package com.example.demo.jobs;
 
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
-import com.example.demo.entity.Apply;
 import com.example.demo.entity.Delivery;
 import com.example.demo.entity.Raffle;
 import com.example.demo.entity.base.enums.DeliveryStatus;
@@ -13,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -36,10 +33,9 @@ public class ExtendAddressJob implements Job {
         deliveryRepository.save(delivery);
 
         Raffle raffle = delivery.getRaffle();
-        List<Apply> applyList = raffle.getApplyList();
-        drawService.cancel(raffle, applyList);
+        drawService.cancel(raffle);
 
-//        emailService.sendWinnerCancelEmail(delivery);
+        emailService.sendWinnerCancelEmail(delivery);
         emailService.sendOwnerCancelEmail(raffle);
     }
 }

--- a/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -22,8 +23,9 @@ public class ExtendShippingJob implements Job {
     private final EmailService emailService;
 
     @Override
+    @Transactional
     public void execute(JobExecutionContext context) {
-        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
@@ -30,6 +30,8 @@ public class ExtendShippingJob implements Job {
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
 
+        // Todo: 배송비 환불
+
         delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
         deliveryRepository.save(delivery);
 
@@ -38,8 +40,6 @@ public class ExtendShippingJob implements Job {
 
         emailService.sendWinnerCancelEmail(delivery);
         emailService.sendOwnerCancelEmail(raffle);
-
-        // Todo: 배송비 환불
 
     }
 }

--- a/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
@@ -25,7 +25,7 @@ public class ExtendShippingJob implements Job {
     @Override
     @Transactional
     public void execute(JobExecutionContext context) {
-        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ExtendShippingJob.java
@@ -2,7 +2,6 @@ package com.example.demo.jobs;
 
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
-import com.example.demo.entity.Apply;
 import com.example.demo.entity.Delivery;
 import com.example.demo.entity.Raffle;
 import com.example.demo.entity.base.enums.DeliveryStatus;
@@ -12,10 +11,7 @@ import com.example.demo.service.general.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -36,10 +32,9 @@ public class ExtendShippingJob implements Job {
         deliveryRepository.save(delivery);
 
         Raffle raffle = delivery.getRaffle();
-        List<Apply> applyList = raffle.getApplyList();
-        drawService.cancel(raffle, applyList);
+        drawService.cancel(raffle);
 
-//        emailService.sendWinnerCancelEmail(delivery);
+        emailService.sendWinnerCancelEmail(delivery);
         emailService.sendOwnerCancelEmail(raffle);
 
         // Todo: 배송비 환불

--- a/src/main/java/com/example/demo/jobs/RaffleEndJob.java
+++ b/src/main/java/com/example/demo/jobs/RaffleEndJob.java
@@ -49,8 +49,10 @@ public class RaffleEndJob implements Job {
 
         updateRaffleStatus(raffle, RaffleStatus.ENDED);
 
-        if (applyList == null || applyList.isEmpty())
-            throw new CustomException(ErrorStatus.DRAW_EMPTY);
+        if (applyList == null || applyList.isEmpty()) {
+            updateRaffleStatus(raffle, RaffleStatus.FINISHED);
+            return;
+        }
 
         drawService.draw(raffle, applyList);
     }

--- a/src/main/java/com/example/demo/jobs/ShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ShippingJob.java
@@ -39,10 +39,10 @@ public class ShippingJob implements Job {
             deliverySchedulerService.scheduleDeliveryJob(delivery);
             emailService.sendWinnerShippingExpiredEmail(delivery);
         } else {
+            // Todo: 배송비 환불
+
             delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
             deliveryRepository.save(delivery);
-
-            // Todo: 배송비 환불
 
             Raffle raffle = delivery.getRaffle();
             drawService.cancel(raffle);

--- a/src/main/java/com/example/demo/jobs/ShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ShippingJob.java
@@ -3,16 +3,15 @@ package com.example.demo.jobs;
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.entity.Delivery;
+import com.example.demo.entity.Raffle;
 import com.example.demo.entity.base.enums.DeliveryStatus;
 import com.example.demo.repository.DeliveryRepository;
 import com.example.demo.service.general.DeliverySchedulerService;
-import com.example.demo.service.general.DeliveryService;
+import com.example.demo.service.general.DrawService;
 import com.example.demo.service.general.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.SchedulerException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,24 +21,32 @@ public class ShippingJob implements Job {
     private final DeliveryRepository deliveryRepository;
     private final DeliverySchedulerService deliverySchedulerService;
     private final EmailService emailService;
+    private final DrawService drawService;
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
+    public void execute(JobExecutionContext context){
         Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
 
-        delivery.setDeliveryStatus(DeliveryStatus.SHIPPING_EXPIRED);
-        deliveryRepository.save(delivery);
+        if (!delivery.isShippingExtended()) {
+            delivery.setDeliveryStatus(DeliveryStatus.SHIPPING_EXPIRED);
+            deliveryRepository.save(delivery);
 
-        try {
             deliverySchedulerService.scheduleDeliveryJob(delivery);
-        } catch (SchedulerException e) {
-            throw new JobExecutionException(e, false);
+            emailService.sendWinnerShippingExpiredEmail(delivery);
+        } else {
+            delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
+            deliveryRepository.save(delivery);
+
+            // Todo: 배송비 환불
+
+            Raffle raffle = delivery.getRaffle();
+            drawService.cancel(raffle);
+
+            emailService.sendWinnerCancelEmail(delivery);
+            emailService.sendOwnerCancelEmail(raffle);
         }
-
-        emailService.sendWinnerShippingExpiredEmail(delivery);
-
     }
 }

--- a/src/main/java/com/example/demo/jobs/ShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ShippingJob.java
@@ -27,7 +27,7 @@ public class ShippingJob implements Job {
     @Override
     @Transactional
     public void execute(JobExecutionContext context){
-        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/jobs/ShippingJob.java
+++ b/src/main/java/com/example/demo/jobs/ShippingJob.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -24,8 +25,9 @@ public class ShippingJob implements Job {
     private final DrawService drawService;
 
     @Override
+    @Transactional
     public void execute(JobExecutionContext context){
-        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+        Long deliveryId = Long.parseLong(context.getJobDetail().getJobDataMap().getString("deliveryId"));
 
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/example/demo/service/general/DeliverySchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/DeliverySchedulerService.java
@@ -1,11 +1,10 @@
 package com.example.demo.service.general;
 
 import com.example.demo.entity.Delivery;
-import org.quartz.SchedulerException;
 
 public interface DeliverySchedulerService {
 
     void scheduleDeliveryJob(Delivery delivery);
 
-    void cancelDeliveryJob(Delivery delivery);
+    void cancelDeliveryJob(Delivery delivery, String type);
 }

--- a/src/main/java/com/example/demo/service/general/DeliverySchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/DeliverySchedulerService.java
@@ -5,5 +5,7 @@ import org.quartz.SchedulerException;
 
 public interface DeliverySchedulerService {
 
-    void scheduleDeliveryJob(Delivery delivery) throws SchedulerException;
+    void scheduleDeliveryJob(Delivery delivery);
+
+    void cancelDeliveryJob(Delivery delivery);
 }

--- a/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
@@ -5,5 +5,5 @@ import org.quartz.SchedulerException;
 
 public interface DrawSchedulerService {
 
-    void scheduleDrawJob(Raffle raffle) throws SchedulerException;
+    void scheduleDrawJob(Raffle raffle);
 }

--- a/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
@@ -1,7 +1,6 @@
 package com.example.demo.service.general;
 
 import com.example.demo.entity.Raffle;
-import org.quartz.SchedulerException;
 
 public interface DrawSchedulerService {
 

--- a/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/DrawSchedulerService.java
@@ -6,4 +6,6 @@ import org.quartz.SchedulerException;
 public interface DrawSchedulerService {
 
     void scheduleDrawJob(Raffle raffle);
+
+    void cancelDrawJob(Raffle raffle);
 }

--- a/src/main/java/com/example/demo/service/general/DrawService.java
+++ b/src/main/java/com/example/demo/service/general/DrawService.java
@@ -11,7 +11,7 @@ public interface DrawService {
 
     Delivery draw(Raffle raffle, List<Apply> applyList);
 
-    void cancel(Raffle raffle, List<Apply> applyList);
+    void cancel(Raffle raffle);
 
     DrawResponseDTO.RaffleResult getDrawRaffle(Long raffleId);
 

--- a/src/main/java/com/example/demo/service/general/EmailService.java
+++ b/src/main/java/com/example/demo/service/general/EmailService.java
@@ -10,11 +10,14 @@ public interface EmailService {
 
     void sendWinnerCancelEmail(Delivery delivery);
 
-    void sendAddressExpiredEmail(Delivery delivery);
+    void sendOwnerAddressExpiredEmail(Delivery delivery);
 
     void sendOwnerCancelEmail(Raffle raffle);
 
     void sendWinnerShippingExpiredEmail(Delivery delivery);
 
+    void sendOwnerUnfulfilledEmail(Raffle raffle);
+
+    void sendOwnerReadyEmail(Delivery delivery);
 
 }

--- a/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.demo.service.general.impl;
 
 import com.example.demo.base.Constants;
+import com.example.demo.base.code.exception.CustomException;
+import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.entity.Delivery;
 import com.example.demo.entity.base.enums.DeliveryStatus;
 import com.example.demo.jobs.*;
@@ -20,40 +22,80 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
     private final Scheduler scheduler;
 
     @Override
-    public void scheduleDeliveryJob(Delivery delivery) throws SchedulerException {
-        if (!scheduler.isStarted()) {
-            scheduler.start();
+    public void scheduleDeliveryJob(Delivery delivery) {
+        try {
+            if (!scheduler.isStarted()) {
+                scheduler.start();
+            }
+
+            JobDetail jobDetail = null;
+            Trigger trigger = null;
+
+            DeliveryStatus deliveryStatus = delivery.getDeliveryStatus();
+            switch (deliveryStatus) {
+                case WAITING_ADDRESS:
+                    jobDetail = buildAddressJobDetail(delivery);
+                    trigger = buildJobTrigger(delivery.getAddressDeadline());
+                    break;
+                case READY:
+                    jobDetail = buildShippingJobDetail(delivery);
+                    trigger = buildJobTrigger(delivery.getShippingDeadline());
+                    break;
+                case ADDRESS_EXPIRED:
+                    jobDetail = buildExtendAddressJobDetail(delivery);
+                    trigger = buildJobTrigger(delivery.getAddressDeadline().plusHours(Constants.WAIT));
+                    break;
+                case SHIPPING_EXPIRED:
+                    jobDetail = buildExtendShippingJobDetail(delivery);
+                    trigger = buildJobTrigger(delivery.getShippingDeadline().plusHours(Constants.WAIT));
+                    break;
+                default:
+                    throw new CustomException(ErrorStatus.INVALID_DELIVERY_STATUS);
+            }
+
+            if (jobDetail == null || trigger == null)
+                throw new CustomException(ErrorStatus.JOB_CREATION_FAILED);
+
+            scheduler.scheduleJob(jobDetail, trigger);
+
+        } catch (SchedulerException e) {
+            Throwable cause = e.getCause();
+
+            if (cause instanceof JobPersistenceException) {
+                // JobPersistenceException: 작업을 저장할 수 없을 때 발생
+                throw new CustomException(ErrorStatus.JOB_STORE_FAILED);
+            } else if (cause instanceof JobExecutionException) {
+                // JobExecutionException: 작업 실행에 문제가 있을 때 발생
+                throw new CustomException(ErrorStatus.JOB_EXECUTION_FAILED);
+            } else {
+                // 그 외 다른 오류들
+                throw new CustomException(ErrorStatus.JOB_UNKNOWN);
+            }
         }
+    }
 
-        JobDetail jobDetail = null;
-        Trigger trigger = null;
+    @Override
+    public void cancelDeliveryJob(Delivery delivery) {
+        try {
+            String jobName = "Delivery_" + delivery.getId();
+            JobKey jobKey = JobKey.jobKey(jobName);
+            TriggerKey triggerKey = TriggerKey.triggerKey(jobName);
 
-        DeliveryStatus deliveryStatus = delivery.getDeliveryStatus();
-        switch (deliveryStatus) {
-            case WAITING_ADDRESS:
-                jobDetail = buildAddressJobDetail(delivery);
-                trigger = buildJobTrigger(delivery.getAddressDeadline());
-                break;
-            case READY:
-                jobDetail = buildShippingJobDetail(delivery);
-                trigger = buildJobTrigger(delivery.getShippingDeadline());
-                break;
-            case ADDRESS_EXPIRED:
-                jobDetail = buildExtendAddressJobDetail(delivery);
-                trigger = buildJobTrigger(delivery.getAddressDeadline().plusHours(Constants.WAIT));
-                break;
-            case SHIPPING_EXPIRED:
-                jobDetail = buildExtendShippingJobDetail(delivery);
-                trigger = buildJobTrigger(delivery.getShippingDeadline().plusHours(Constants.WAIT));
-                break;
+            if (scheduler.checkExists(jobKey)) {
+                scheduler.unscheduleJob(triggerKey);
+                scheduler.deleteJob(jobKey);
+            }
+            else
+                throw new CustomException(ErrorStatus.JOB_NOT_FOUND);
+
+        } catch (SchedulerException e) {
+            throw new CustomException(ErrorStatus.JOB_CANCEL_FAILED);
         }
-
-        scheduler.scheduleJob(jobDetail, trigger);
     }
 
     private JobDetail buildAddressJobDetail(Delivery delivery) {
         return JobBuilder.newJob(AddressJob.class)
-                .withIdentity("Delivery_" + delivery.getId() + "_WAITING_ADDRESS")
+                .withIdentity("Delivery_" + delivery.getId())
                 .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();
@@ -61,7 +103,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
 
     private JobDetail buildShippingJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ShippingJob.class)
-                .withIdentity("Delivery_" + delivery.getId() + "_READY")
+                .withIdentity("Delivery_" + delivery.getId())
                 .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();
@@ -69,7 +111,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
 
     private JobDetail buildExtendAddressJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ExtendAddressJob.class)
-                .withIdentity("Delivery_" + delivery.getId() + "_ADDRESS_EXPIRED")
+                .withIdentity("Delivery_" + delivery.getId())
                 .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();
@@ -77,7 +119,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
 
     private JobDetail buildExtendShippingJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ExtendShippingJob.class)
-                .withIdentity("Delivery_" + delivery.getId() + "_SHIPPING_EXPIRED")
+                .withIdentity("Delivery_" + delivery.getId())
                 .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();

--- a/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
@@ -96,7 +96,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
     private JobDetail buildAddressJobDetail(Delivery delivery) {
         return JobBuilder.newJob(AddressJob.class)
                 .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", delivery.getId())
+                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
                 .storeDurably()
                 .build();
     }
@@ -104,7 +104,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
     private JobDetail buildShippingJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ShippingJob.class)
                 .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", delivery.getId())
+                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
                 .storeDurably()
                 .build();
     }
@@ -112,7 +112,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
     private JobDetail buildExtendAddressJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ExtendAddressJob.class)
                 .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", delivery.getId())
+                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
                 .storeDurably()
                 .build();
     }
@@ -120,7 +120,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
     private JobDetail buildExtendShippingJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ExtendShippingJob.class)
                 .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", delivery.getId())
+                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
                 .storeDurably()
                 .build();
     }

--- a/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
@@ -59,6 +59,7 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
             scheduler.scheduleJob(jobDetail, trigger);
 
         } catch (SchedulerException e) {
+            System.out.println("SchedulerException occurred: " + e.getMessage());
             Throwable cause = e.getCause();
 
             if (cause instanceof JobPersistenceException) {
@@ -75,9 +76,9 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
     }
 
     @Override
-    public void cancelDeliveryJob(Delivery delivery) {
+    public void cancelDeliveryJob(Delivery delivery, String type) {
         try {
-            String jobName = "Delivery_" + delivery.getId();
+            String jobName = "Delivery_" + delivery.getId() + "_" + type;
             JobKey jobKey = JobKey.jobKey(jobName);
             TriggerKey triggerKey = TriggerKey.triggerKey(jobName);
 
@@ -95,32 +96,32 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
 
     private JobDetail buildAddressJobDetail(Delivery delivery) {
         return JobBuilder.newJob(AddressJob.class)
-                .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
+                .withIdentity("Delivery_" + delivery.getId() + "_Address")
+                .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();
     }
 
     private JobDetail buildShippingJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ShippingJob.class)
-                .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
+                .withIdentity("Delivery_" + delivery.getId() + "_Shipping")
+                .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();
     }
 
     private JobDetail buildExtendAddressJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ExtendAddressJob.class)
-                .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
+                .withIdentity("Delivery_" + delivery.getId() + "_ExtendAddress")
+                .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();
     }
 
     private JobDetail buildExtendShippingJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ExtendShippingJob.class)
-                .withIdentity("Delivery_" + delivery.getId())
-                .usingJobData("deliveryId", String.valueOf(delivery.getId()))
+                .withIdentity("Delivery_" + delivery.getId() + "_ExtendShipping")
+                .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();
     }

--- a/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.demo.domain.dto.Mypage.MypageResponseDTO;
 import com.example.demo.entity.*;
 import com.example.demo.entity.base.enums.DeliveryStatus;
 import com.example.demo.repository.*;
+import com.example.demo.service.general.DeliverySchedulerService;
 import com.example.demo.service.general.DeliveryService;
 import com.example.demo.service.general.DrawService;
 import com.example.demo.service.general.EmailService;
@@ -32,6 +33,8 @@ public class DeliveryServiceImpl implements DeliveryService {
     private final UserRepository userRepository;
     private final ApplyRepository applyRepository;
     private final DrawService drawService;
+    private final DeliverySchedulerService deliverySchedulerService;
+    private final EmailService emailService;
 
     @Override
     public DeliveryResponseDTO.DeliveryDto getDelivery(Long deliveryId) {
@@ -105,9 +108,13 @@ public class DeliveryServiceImpl implements DeliveryService {
         if (deliveryStatus != DeliveryStatus.WAITING_PAYMENT)
             throw new CustomException(ErrorStatus.DELIVERY_ALREADY_READY);
 
+        deliverySchedulerService.cancelDeliveryJob(delivery);
+
         delivery.setDeliveryStatus(DeliveryStatus.READY);
         delivery.setShippingDeadline();
         deliveryRepository.save(delivery);
+
+        emailService.sendOwnerReadyEmail(delivery);
 
         return DeliveryResponseDTO.ResponseDto.builder()
                 .deliveryId(deliveryId)
@@ -138,9 +145,13 @@ public class DeliveryServiceImpl implements DeliveryService {
 
         if (delivery.isShippingExtended())
             throw new CustomException(ErrorStatus.DELIVERY_ALREADY_EXTEND);
+
+        deliverySchedulerService.cancelDeliveryJob(delivery);
       
         delivery.extendShippingDeadline();
         deliveryRepository.save(delivery);
+
+        deliverySchedulerService.scheduleDeliveryJob(delivery);
 
         return toWaitDto(delivery);
     }
@@ -168,11 +179,13 @@ public class DeliveryServiceImpl implements DeliveryService {
         }
 
         Raffle raffle = delivery.getRaffle();
-        List<Apply> applyList = applyRepository.findByRaffle(raffle);
-        drawService.cancel(raffle, applyList);
+        drawService.cancel(raffle);
 
         delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
         deliveryRepository.save(delivery);
+
+        deliverySchedulerService.cancelDeliveryJob(delivery);
+        emailService.sendOwnerCancelEmail(raffle);
 
         return String.format(Constants.DELIVERY_WINNER_URL, delivery.getId());
     }
@@ -220,9 +233,14 @@ public class DeliveryServiceImpl implements DeliveryService {
                 throw new CustomException(ErrorStatus.DELIVERY_CANCELLED);
         }
 
+        deliverySchedulerService.cancelDeliveryJob(delivery);
+
         delivery.setInvoiceNumber(deliveryRequestDTO.getInvoiceNumber());
         delivery.setDeliveryStatus(DeliveryStatus.SHIPPED);
         deliveryRepository.save(delivery);
+
+        // Todo: 자동 수령 완료 설정
+//        deliverySchedulerService.scheduleDeliveryJob(delivery);
 
         return DeliveryResponseDTO.ResponseDto.builder()
                 .deliveryId(deliveryId)
@@ -255,8 +273,12 @@ public class DeliveryServiceImpl implements DeliveryService {
         if (delivery.isAddressExtended())
             throw new CustomException(ErrorStatus.DELIVERY_ALREADY_EXTEND);
 
+        deliverySchedulerService.cancelDeliveryJob(delivery);
+
         delivery.extendAddressDeadline();
         deliveryRepository.save(delivery);
+
+        deliverySchedulerService.scheduleDeliveryJob(delivery);
 
         return toWaitDto(delivery);
     }

--- a/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
@@ -181,13 +181,16 @@ public class DeliveryServiceImpl implements DeliveryService {
                 throw new CustomException(ErrorStatus.DELIVERY_CANCELLED);
         }
 
-        Raffle raffle = delivery.getRaffle();
-        drawService.cancel(raffle);
+        deliverySchedulerService.cancelDeliveryJob(delivery, "ExtendShipping");
+
+        // Todo: 배송비 환불
 
         delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
         deliveryRepository.save(delivery);
 
-        deliverySchedulerService.cancelDeliveryJob(delivery, "ExtendShipping");
+        Raffle raffle = delivery.getRaffle();
+        drawService.cancel(raffle);
+
         emailService.sendOwnerCancelEmail(raffle);
 
         return String.format(Constants.DELIVERY_WINNER_URL, delivery.getId());

--- a/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
@@ -108,13 +108,15 @@ public class DeliveryServiceImpl implements DeliveryService {
         if (deliveryStatus != DeliveryStatus.WAITING_PAYMENT)
             throw new CustomException(ErrorStatus.DELIVERY_ALREADY_READY);
 
-        deliverySchedulerService.cancelDeliveryJob(delivery);
+        deliverySchedulerService.cancelDeliveryJob(delivery, "Address");
 
         delivery.setDeliveryStatus(DeliveryStatus.READY);
         delivery.setShippingDeadline();
         deliveryRepository.save(delivery);
 
         emailService.sendOwnerReadyEmail(delivery);
+
+        deliverySchedulerService.scheduleDeliveryJob(delivery);
 
         return DeliveryResponseDTO.ResponseDto.builder()
                 .deliveryId(deliveryId)
@@ -146,7 +148,8 @@ public class DeliveryServiceImpl implements DeliveryService {
         if (delivery.isShippingExtended())
             throw new CustomException(ErrorStatus.DELIVERY_ALREADY_EXTEND);
 
-        deliverySchedulerService.cancelDeliveryJob(delivery);
+        deliverySchedulerService.cancelDeliveryJob(delivery, "ExtendShipping");
+        deliverySchedulerService.cancelDeliveryJob(delivery, "Shipping");
       
         delivery.extendShippingDeadline();
         deliveryRepository.save(delivery);
@@ -184,7 +187,7 @@ public class DeliveryServiceImpl implements DeliveryService {
         delivery.setDeliveryStatus(DeliveryStatus.CANCELLED);
         deliveryRepository.save(delivery);
 
-        deliverySchedulerService.cancelDeliveryJob(delivery);
+        deliverySchedulerService.cancelDeliveryJob(delivery, "ExtendShipping");
         emailService.sendOwnerCancelEmail(raffle);
 
         return String.format(Constants.DELIVERY_WINNER_URL, delivery.getId());
@@ -233,7 +236,7 @@ public class DeliveryServiceImpl implements DeliveryService {
                 throw new CustomException(ErrorStatus.DELIVERY_CANCELLED);
         }
 
-        deliverySchedulerService.cancelDeliveryJob(delivery);
+        deliverySchedulerService.cancelDeliveryJob(delivery, "Shipping");
 
         delivery.setInvoiceNumber(deliveryRequestDTO.getInvoiceNumber());
         delivery.setDeliveryStatus(DeliveryStatus.SHIPPED);
@@ -273,7 +276,8 @@ public class DeliveryServiceImpl implements DeliveryService {
         if (delivery.isAddressExtended())
             throw new CustomException(ErrorStatus.DELIVERY_ALREADY_EXTEND);
 
-        deliverySchedulerService.cancelDeliveryJob(delivery);
+        deliverySchedulerService.cancelDeliveryJob(delivery, "ExtendAddress");
+        deliverySchedulerService.cancelDeliveryJob(delivery, "Address");
 
         delivery.extendAddressDeadline();
         deliveryRepository.save(delivery);

--- a/src/main/java/com/example/demo/service/general/impl/DrawSchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawSchedulerServiceImpl.java
@@ -47,10 +47,29 @@ public class DrawSchedulerServiceImpl implements DrawSchedulerService {
         }
     }
 
+    @Override
+    public void cancelDrawJob(Raffle raffle) {
+        try {
+            String jobName = "Raffle_" + raffle.getId();
+            JobKey jobKey = JobKey.jobKey(jobName);
+            TriggerKey triggerKey = TriggerKey.triggerKey(jobName);
+
+            if (scheduler.checkExists(jobKey)) {
+                scheduler.unscheduleJob(triggerKey);
+                scheduler.deleteJob(jobKey);
+            }
+            else
+                throw new CustomException(ErrorStatus.JOB_NOT_FOUND);
+
+        } catch (SchedulerException e) {
+            throw new CustomException(ErrorStatus.JOB_CANCEL_FAILED);
+        }
+    }
+
     private JobDetail buildDrawJobDetail(Raffle raffle) {
         return JobBuilder.newJob(ExtendShippingJob.class)
-                .withIdentity("Raffle_" + raffle.getId() + "_UNFULFILLED")
-                .usingJobData("raffleId", raffle.getId())
+                .withIdentity("Raffle_" + raffle.getId())
+                .usingJobData("raffleId", String.valueOf(raffle.getId()))
                 .storeDurably()
                 .build();
     }

--- a/src/main/java/com/example/demo/service/general/impl/DrawSchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawSchedulerServiceImpl.java
@@ -4,7 +4,7 @@ import com.example.demo.base.Constants;
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
 import com.example.demo.entity.Raffle;
-import com.example.demo.jobs.ExtendShippingJob;
+import com.example.demo.jobs.DrawJob;
 import com.example.demo.service.general.DrawSchedulerService;
 import lombok.RequiredArgsConstructor;
 import org.quartz.*;
@@ -67,9 +67,9 @@ public class DrawSchedulerServiceImpl implements DrawSchedulerService {
     }
 
     private JobDetail buildDrawJobDetail(Raffle raffle) {
-        return JobBuilder.newJob(ExtendShippingJob.class)
+        return JobBuilder.newJob(DrawJob.class)
                 .withIdentity("Raffle_" + raffle.getId())
-                .usingJobData("raffleId", String.valueOf(raffle.getId()))
+                .usingJobData("raffleId", raffle.getId())
                 .storeDurably()
                 .build();
     }

--- a/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.demo.entity.base.enums.DeliveryStatus;
 import com.example.demo.entity.base.enums.RaffleStatus;
 import com.example.demo.repository.*;
 import com.example.demo.service.general.DeliverySchedulerService;
+import com.example.demo.service.general.DrawSchedulerService;
 import com.example.demo.service.general.DrawService;
 import com.example.demo.service.general.EmailService;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class DrawServiceImpl implements DrawService {
     private final DeliveryRepository deliveryRepository;
     private final EmailService emailService;
     private final DeliverySchedulerService deliverySchedulerService;
+    private final DrawSchedulerService drawSchedulerService;
 
     @Override
     @Transactional
@@ -178,6 +180,8 @@ public class DrawServiceImpl implements DrawService {
                 throw new CustomException(ErrorStatus.DRAW_FINISHED);
         }
 
+        drawSchedulerService.cancelDrawJob(raffle);
+
         List<Apply> applyList = applyRepository.findByRaffle(raffle);
 
         if (applyList.isEmpty())
@@ -199,6 +203,8 @@ public class DrawServiceImpl implements DrawService {
         RaffleStatus raffleStatus = raffle.getRaffleStatus();
         validateRaffleStatus(raffleStatus);
         validateCancel(raffle, raffleStatus);
+
+        drawSchedulerService.cancelDrawJob(raffle);
 
         cancel(raffle);
 
@@ -278,6 +284,8 @@ public class DrawServiceImpl implements DrawService {
 
                 if (deliveryStatus != DeliveryStatus.ADDRESS_EXPIRED)
                     throw new CustomException(ErrorStatus.CANCEL_FAIL);
+
+                deliverySchedulerService.cancelDeliveryJob(delivery);
 
                 emailService.sendWinnerCancelEmail(delivery);
 

--- a/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
@@ -285,7 +285,7 @@ public class DrawServiceImpl implements DrawService {
                 if (deliveryStatus != DeliveryStatus.ADDRESS_EXPIRED)
                     throw new CustomException(ErrorStatus.CANCEL_FAIL);
 
-                deliverySchedulerService.cancelDeliveryJob(delivery);
+                deliverySchedulerService.cancelDeliveryJob(delivery, "ExtendAddress");
 
                 emailService.sendWinnerCancelEmail(delivery);
 

--- a/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
@@ -16,8 +16,6 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
-import java.time.format.DateTimeFormatter;
-
 
 @Service
 public class EmailServiceImpl implements EmailService {
@@ -40,9 +38,6 @@ public class EmailServiceImpl implements EmailService {
 
         try {
 
-            if (user.getEmail() == null)
-                throw new CustomException(ErrorStatus.DRAW_NO_WINNER_EMAIL);
-
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
@@ -57,7 +52,6 @@ public class EmailServiceImpl implements EmailService {
             context.setVariable("raffleName", raffle.getName());
             context.setVariable("deliveryUrl", String.format(Constants.DELIVERY_WINNER_URL, delivery.getId()));
 
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
             context.setVariable("deliveryInfoEnd", delivery.getAddressDeadline());
             context.setVariable("fromEmail", fromEmail);
 
@@ -77,9 +71,6 @@ public class EmailServiceImpl implements EmailService {
         Raffle raffle = delivery.getRaffle();
 
         try {
-
-            if (user.getEmail() == null)
-                throw new CustomException(ErrorStatus.DRAW_NO_WINNER_EMAIL);
 
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -105,7 +96,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    public void sendAddressExpiredEmail(Delivery delivery) {
+    public void sendOwnerAddressExpiredEmail(Delivery delivery) {
         User user = delivery.getUser();
         Raffle raffle = delivery.getRaffle();
 
@@ -187,6 +178,72 @@ public class EmailServiceImpl implements EmailService {
             context.setVariable("fromEmail", fromEmail);
 
             String body = templateEngine.process("WinnerShippingExpiredEmail.html", context);
+            helper.setText(body, true);
+
+            mailSender.send(helper.getMimeMessage());
+
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorStatus.DRAW_EMAIL_FAILED);
+        }
+    }
+
+    @Override
+    public void sendOwnerUnfulfilledEmail(Raffle raffle) {
+        User user = raffle.getUser();
+
+        try {
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(user.getEmail());
+            helper.setFrom(fromEmail);
+
+            String subject = "[장마당] " + raffle.getName() + " 미추첨 안내";
+            helper.setSubject(subject);
+
+            Context context = new Context();
+            context.setVariable("userName", user.getNickname());
+            context.setVariable("raffleName", raffle.getName());
+            context.setVariable("url", String.format(Constants.RAFFLE_OWNER_URL, raffle.getId()));
+            context.setVariable("fromEmail", fromEmail);
+
+            String body = templateEngine.process("OwnerUnfulfilledEmail.html", context);
+            helper.setText(body, true);
+
+            mailSender.send(helper.getMimeMessage());
+
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorStatus.DRAW_EMAIL_FAILED);
+        }
+
+    }
+
+    @Override
+    public void sendOwnerReadyEmail(Delivery delivery) {
+        User user = delivery.getUser();
+        Raffle raffle = delivery.getRaffle();
+
+        try {
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(user.getEmail());
+            helper.setFrom(fromEmail);
+
+            String subject = "[장마당] " + raffle.getName() + " 운송장 입력 안내";
+            helper.setSubject(subject);
+
+            Context context = new Context();
+            context.setVariable("userName", user.getNickname());
+            context.setVariable("raffleName", raffle.getName());
+            context.setVariable("deliveryUrl", String.format(Constants.DELIVERY_OWNER_URL, delivery.getId()));
+
+            context.setVariable("deliveryInfoEnd", delivery.getShippingDeadline());
+            context.setVariable("fromEmail", fromEmail);
+
+            String body = templateEngine.process("OwnerReadyEmail.html", context);
             helper.setText(body, true);
 
             mailSender.send(helper.getMimeMessage());

--- a/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
@@ -113,7 +113,8 @@ public class EmailServiceImpl implements EmailService {
 
             Context context = new Context();
             context.setVariable("userName", user.getNickname());
-            context.setVariable("url", String.format(Constants.DELIVERY_OWNER_URL, delivery.getId()));
+            context.setVariable("deliveryUrl", String.format(Constants.DELIVERY_OWNER_URL, delivery.getId()));
+
             context.setVariable("fromEmail", fromEmail);
 
             String body = templateEngine.process("OwnerAddressExpiredEmail.html", context);
@@ -174,7 +175,7 @@ public class EmailServiceImpl implements EmailService {
 
             Context context = new Context();
             context.setVariable("userName", user.getNickname());
-//            context.setVariable("url", String.format(Constants.DELIVERY_WINNER_URL, delivery.getId()));
+            context.setVariable("deliveryUrl", String.format(Constants.DELIVERY_WINNER_URL, delivery.getId()));
             context.setVariable("fromEmail", fromEmail);
 
             String body = templateEngine.process("WinnerShippingExpiredEmail.html", context);
@@ -205,7 +206,7 @@ public class EmailServiceImpl implements EmailService {
             Context context = new Context();
             context.setVariable("userName", user.getNickname());
             context.setVariable("raffleName", raffle.getName());
-            context.setVariable("url", String.format(Constants.RAFFLE_OWNER_URL, raffle.getId()));
+            context.setVariable("deliveryUrl", String.format(Constants.RAFFLE_OWNER_URL, raffle.getId()));
             context.setVariable("fromEmail", fromEmail);
 
             String body = templateEngine.process("OwnerUnfulfilledEmail.html", context);

--- a/src/main/java/com/example/demo/service/general/impl/RaffleSchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/RaffleSchedulerServiceImpl.java
@@ -32,18 +32,14 @@ public class RaffleSchedulerServiceImpl implements RaffleSchedulerService {
             scheduler.scheduleJob(jobDetail, trigger);
 
         } catch (SchedulerException e) {
-            Throwable cause = e.getCause();  // 원인 예외 분석
+            Throwable cause = e.getCause();
 
-            // 예외 처리 로직
             if (cause instanceof JobPersistenceException) {
                 // JobPersistenceException: 작업을 저장할 수 없을 때 발생
                 throw new CustomException(ErrorStatus.JOB_STORE_FAILED);
             } else if (cause instanceof JobExecutionException) {
                 // JobExecutionException: 작업 실행에 문제가 있을 때 발생
                 throw new CustomException(ErrorStatus.JOB_EXECUTION_FAILED);
-//            } else if (cause instanceof JobInterruptException) {
-//              // JobInterruptException: 작업이 인터럽트되었을 때 발생
-//                throw new CustomException(ErrorStatus.JOB_INTERRUPT);
             } else {
                 // 그 외 다른 오류들
                 throw new CustomException(ErrorStatus.JOB_UNKNOWN);

--- a/src/main/resources/templates/OwnerAddressExpiredEmail.html
+++ b/src/main/resources/templates/OwnerAddressExpiredEmail.html
@@ -70,7 +70,7 @@
         <p>기한 내에 연장하지 않으시면 해당 래플은 취소되며, 응모된 티켓은 <span class="highlight">모든 응모자에게 반환</span>됩니다.</p>
 
         <p>### <span class="highlight">아래 URL에 접속해 연장 여부를 선택해주세요</span></p>
-        <a th:href="@{${url}}" class="button">24시간 연장 선택</a>
+        <p><a th:href="${deliveryUrl}">24시간 연장 선택</a></p>
 
         <p>※ 24시간 연장 기한이 지나면 자동으로 응모한 티켓이 반환되며 래플은 취소됩니다.</p>
 

--- a/src/main/resources/templates/OwnerReadyEmail.html
+++ b/src/main/resources/templates/OwnerReadyEmail.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>당첨 안내</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #f9f9f9;
+            color: #333;
+        }
+        .container {
+            width: 600px;
+            margin: 30px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #5C6BC0;
+        }
+        h2 {
+            color: #F44336;
+        }
+        .content {
+            margin-bottom: 20px;
+        }
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+        ul li {
+            padding: 8px 0;
+        }
+        .cta-button {
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 10px 15px;
+            border-radius: 5px;
+            text-decoration: none;
+            font-weight: bold;
+        }
+        .cta-button:hover {
+            background-color: #45a049;
+        }
+        .footer {
+            margin-top: 30px;
+            text-align: center;
+            color: #888;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+    <h1>안녕하세요, <b th:text="${userName}"> </b>님!</h1>
+    <p class="content">먼저, 장마당 래플 서비스에 참여해주셔서 진심으로 감사드립니다. 🎁</p>
+    <p><b th:text="${raffleName}"></b> 래플의 당첨자가 배송지 입력 및 배송비 결제를 완료하였습니다! </p>
+
+    <p class="content">배송 정보와 다음 절차를 아래에서 확인해 주세요.</p>
+    <p><a th:href="${deliveryUrl}">배송 정보 확인하기</a></p>
+
+    <h3>🎯 다음 단계 안내:</h3>
+    <ul>
+        <li><strong>운송장 등록:</strong> <span th:text="${deliveryInfoEnd}"> </span>까지 배송지 정보를 확인하고 상품을 발송해 주세요. 기한 내에 등록을 하지 않으시면 해당 래플은 취소됩니다.</li>
+        <li><strong>배송 진행 상황:</strong> 마이페이지에서 배송 상황을 실시간으로 확인하실 수 있습니다.</li>
+    </ul>
+
+    <p class="content">문의 사항이 있으시면, 래플 내 문의하기 기능을 사용하시거나 <a th:href="'mailto:' + ${fromEmail}">[고객센터 이메일]</a>로 연락해 주세요.</p>
+
+    <p>다시 한 번 장마당 서비스를 이용해 주셔서 감사드리며, 향후 더 좋은 기회로 찾아뵙겠습니다.</p>
+
+    <p>감사합니다.</p>
+
+</div>
+
+<div class="footer">
+    <p>본 메일은 발신 전용입니다. 문의사항이 있으시면 <a th:href="'mailto:' + ${fromEmail}">[고객센터 이메일]</a>로 연락 부탁드립니다.</p>
+</div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/OwnerUnfulfilledEmail.html
+++ b/src/main/resources/templates/OwnerUnfulfilledEmail.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>배송지 입력 및 결제 기한 만료 안내</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            width: 100%;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .header h1 {
+            color: #4CAF50;
+            font-size: 24px;
+        }
+        .content {
+            margin-bottom: 20px;
+        }
+        .content p {
+            font-size: 16px;
+            margin: 10px 0;
+        }
+        .content .highlight {
+            font-weight: bold;
+            color: #e74c3c;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 20px;
+            font-size: 16px;
+            color: #fff;
+            background-color: #4CAF50;
+            text-align: center;
+            text-decoration: none;
+            border-radius: 5px;
+            margin-top: 20px;
+        }
+        .footer {
+            text-align: center;
+            font-size: 14px;
+            color: #999;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="header">
+        <h1>래플 미추첨 안내</h1>
+    </div>
+    <div class="content">
+        <p>안녕하세요, <b th:text="${userName}"></b>님!</p>
+        <p>먼저, 장마당 래플 서비스에 참여해 주셔서 감사합니다.</p>
+        <p>하지만, <b th:text="${raffleName}"></b> 래플이 최소 티켓 수 미충족으로 추첨이 진행되지 않았습니다.</p>
+        <p>따라서, 24시간 동안 수동으로 추첨하실 기회가 제공됩니다.</p>
+        <p>기한 내에 추첨하지 않으시면 해당 래플은 취소되며, 응모된 티켓은 <span class="highlight">모든 응모자에게 반환</span>됩니다.</p>
+
+        <p>### <span class="highlight">아래 URL에 접속해 추첨 여부를 선택해주세요</span></p>
+        <a th:href="@{${url}}" class="button">수동 추첨 선택</a>
+
+        <p>※ 24시간이 지나면 자동으로 응모한 티켓이 반환되며 래플은 취소됩니다.</p>
+
+        <p><span class="highlight">주의사항</span><br>
+            - 기한이 지나면 더 이상의 추첨은 불가하며, 해당 래플은 취소 처리됩니다.<br>
+            - 또한, 강제로 종료시킬 수도 있습니다.<br>
+        </p>
+
+        <p>다시 한 번 장마당 서비스를 이용해 주셔서 감사드리며, 향후 더 좋은 기회로 찾아뵙겠습니다.</p>
+
+        <p>감사합니다.</p>
+
+    </div>
+
+    <div class="footer">
+        <p>본 메일은 발신 전용입니다. 문의사항이 있으시면 <a th:href="'mailto:' + ${fromEmail}">[고객센터 이메일]</a>로 연락 부탁드립니다.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/OwnerUnfulfilledEmail.html
+++ b/src/main/resources/templates/OwnerUnfulfilledEmail.html
@@ -71,7 +71,7 @@
         <p>기한 내에 추첨하지 않으시면 해당 래플은 취소되며, 응모된 티켓은 <span class="highlight">모든 응모자에게 반환</span>됩니다.</p>
 
         <p>### <span class="highlight">아래 URL에 접속해 추첨 여부를 선택해주세요</span></p>
-        <a th:href="@{${url}}" class="button">수동 추첨 선택</a>
+        <p><a th:href="${deliveryUrl}">수동 추첨 선택</a></p>
 
         <p>※ 24시간이 지나면 자동으로 응모한 티켓이 반환되며 래플은 취소됩니다.</p>
 

--- a/src/main/resources/templates/WinnerShippingExpiredEmail.html
+++ b/src/main/resources/templates/WinnerShippingExpiredEmail.html
@@ -70,7 +70,7 @@
         <p>기한 내에 연장하지 않으시면 해당 래플은 취소되며, 응모된 티켓은 <span class="highlight">모든 응모자에게 반환</span>됩니다.</p>
 
         <p>### <span class="highlight">아래 URL에 접속해 연장 여부를 선택해주세요</span></p>
-        <a th:href="@{${url}}" class="button">24시간 연장 선택</a>
+        <p><a th:href="${deliveryUrl}">24시간 연장 선택</a></p>
 
         <p>※ 24시간 연장 기한이 지나면 자동으로 응모한 티켓이 반환되며 래플은 취소됩니다.</p>
 


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #102 

## 📝 작업 내용

추첨 이후 각 작업(배송지 입력, 운송장 입력, 연장)이 수행된 시점과 경과 시간에 따라 배송 및 래플의 상태를 변경하는 Job을 호출 및 취소하는 로직을 구현하였습니다.

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
로직이 다소 복잡하여 노션에 정리된 것을 함께 보시며 확인 부탁드립니다.
