### PR TITLE
✨[FEAT] #104: 상품 수령 완료

### DIFF
--- a/src/main/java/com/example/demo/base/Constants.java
+++ b/src/main/java/com/example/demo/base/Constants.java
@@ -14,6 +14,9 @@ public class Constants {
     // 배송지/운송장 입력 기한 연장 (시간 단위)
     public static final int WAIT = 24;
 
+    // 수령 완료 기한(7일) (시간 단위)
+    public static final int COMPLETE = 168;
+
     // 추첨 완료된 래플 개최자 리디렉션 url
     public static final String DELIVERY_OWNER_URL = "/api/permit/delivery/%d/owner";
 

--- a/src/main/java/com/example/demo/base/status/ErrorStatus.java
+++ b/src/main/java/com/example/demo/base/status/ErrorStatus.java
@@ -106,6 +106,8 @@ public enum ErrorStatus implements BaseErrorCode {
     DELIVERY_CANCELLED(HttpStatus.BAD_REQUEST, "DELIVERY_4011", "당첨이 취소되었습니다."),
     DELIVERY_NO_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "DELIVERY_4012", "기본 배송지가 없습니다."),
     DELIVERY_ALREADY_EXTEND(HttpStatus.BAD_REQUEST, "DELIVERY_4013", "한번 이상 연장할 수 없습니다."),
+    DELIVERY_BEFORE_SHIPPING(HttpStatus.BAD_REQUEST, "DELIVERY_4014", "아직 운송장이 등록되지 않았습니다."),
+    DELIVERY_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "DELIVERY_4015", "이미 수령 완료된 배송입니다."),
 
     // 15. Huiju - 주소 관련 에러
     ADDRESS_EMPTY(HttpStatus.BAD_REQUEST, "ADDRESS_4001", "사용자에게 등록된 주소가 없습니다."),

--- a/src/main/java/com/example/demo/controller/general/DeliveryController.java
+++ b/src/main/java/com/example/demo/controller/general/DeliveryController.java
@@ -57,6 +57,13 @@ public class DeliveryController {
         response.sendRedirect(redirectUrl);
     }
 
+    @Operation(summary = "당첨자 - 배송 완료 처리하기")
+    @PostMapping("{deliveryId}/winner/success")
+    public ApiResponse<DeliveryResponseDTO.ResponseDto> success(@PathVariable Long deliveryId) {
+
+        return ApiResponse.of(_OK, deliveryService.success(deliveryId));
+    }
+
     @Operation(summary = "개최자 - 배송 정보 확인하기")
     @GetMapping("{deliveryId}/owner")
     public ApiResponse<DeliveryResponseDTO.ResultDto> getResult(@PathVariable Long deliveryId) {

--- a/src/main/java/com/example/demo/domain/converter/DeliveryConverter.java
+++ b/src/main/java/com/example/demo/domain/converter/DeliveryConverter.java
@@ -63,4 +63,10 @@ public class DeliveryConverter {
                 .build();
     }
 
+    public static DeliveryResponseDTO.ResponseDto toResponseDto(Long deliveryId) {
+        return DeliveryResponseDTO.ResponseDto.builder()
+                .deliveryId(deliveryId)
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/demo/entity/base/enums/DeliveryStatus.java
+++ b/src/main/java/com/example/demo/entity/base/enums/DeliveryStatus.java
@@ -7,5 +7,6 @@ public enum DeliveryStatus {
     SHIPPED,        // 운송장 입력 완료 (발송 완료)
     CANCELLED,      // 당첨 취소
     ADDRESS_EXPIRED,    // 배송지 입력 기한 만료
-    SHIPPING_EXPIRED     // 운송장 입력 기한 만료
+    SHIPPING_EXPIRED,     // 운송장 입력 기한 만료
+    COMPLETED           // 상품 수령 완료
 }

--- a/src/main/java/com/example/demo/entity/base/enums/RaffleStatus.java
+++ b/src/main/java/com/example/demo/entity/base/enums/RaffleStatus.java
@@ -5,5 +5,6 @@ public enum RaffleStatus {
     ACTIVE,     // 응모 중
     UNFULFILLED,    // 최소 티켓 수 미충족 마감
     ENDED,       // 응모 마감 및 당첨자 추첨 완료
-    FINISHED     // 완전 종료
+    FINISHED,     // 완전 종료
+    COMPLETED       // 상품 수령 완료
 }

--- a/src/main/java/com/example/demo/jobs/CompleteJob.java
+++ b/src/main/java/com/example/demo/jobs/CompleteJob.java
@@ -1,0 +1,32 @@
+package com.example.demo.jobs;
+
+import com.example.demo.base.code.exception.CustomException;
+import com.example.demo.base.status.ErrorStatus;
+import com.example.demo.entity.Delivery;
+import com.example.demo.repository.DeliveryRepository;
+import com.example.demo.service.general.DeliveryService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CompleteJob implements Job {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryService deliveryService;
+
+    @Override
+    @Transactional
+    public void execute(JobExecutionContext context) {
+        Long deliveryId = context.getJobDetail().getJobDataMap().getLong("deliveryId");
+
+        Delivery delivery = deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NOT_FOUND));
+
+        deliveryService.finalize(delivery);
+
+    }
+}

--- a/src/main/java/com/example/demo/service/general/DeliveryService.java
+++ b/src/main/java/com/example/demo/service/general/DeliveryService.java
@@ -2,6 +2,7 @@ package com.example.demo.service.general;
 
 import com.example.demo.domain.dto.Delivery.DeliveryRequestDTO;
 import com.example.demo.domain.dto.Delivery.DeliveryResponseDTO;
+import com.example.demo.entity.Delivery;
 
 public interface DeliveryService {
     DeliveryResponseDTO.DeliveryDto getDelivery(Long deliveryId);
@@ -14,10 +15,14 @@ public interface DeliveryService {
 
     String cancel(Long deliveryId);
 
+    DeliveryResponseDTO.ResponseDto success(Long deliveryId);
+
     DeliveryResponseDTO.ResultDto getResult(Long deliveryId);
 
     DeliveryResponseDTO.ResponseDto addInvoice(Long deliveryId, DeliveryRequestDTO deliveryRequestDTO);
 
     DeliveryResponseDTO.WaitDto waitAddress(Long deliveryId);
+
+    void finalize(Delivery delivery);
 
 }

--- a/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliverySchedulerServiceImpl.java
@@ -41,6 +41,9 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
                     jobDetail = buildShippingJobDetail(delivery);
                     trigger = buildJobTrigger(delivery.getShippingDeadline());
                     break;
+                case SHIPPED:
+                    jobDetail = buildCompleteJobDetail(delivery);
+                    trigger = buildJobTrigger(LocalDateTime.now().withSecond(0).withNano(0).plusHours(Constants.COMPLETE));
                 case ADDRESS_EXPIRED:
                     jobDetail = buildExtendAddressJobDetail(delivery);
                     trigger = buildJobTrigger(delivery.getAddressDeadline().plusHours(Constants.WAIT));
@@ -105,6 +108,14 @@ public class DeliverySchedulerServiceImpl implements DeliverySchedulerService {
     private JobDetail buildShippingJobDetail(Delivery delivery) {
         return JobBuilder.newJob(ShippingJob.class)
                 .withIdentity("Delivery_" + delivery.getId() + "_Shipping")
+                .usingJobData("deliveryId", delivery.getId())
+                .storeDurably()
+                .build();
+    }
+
+    private JobDetail buildCompleteJobDetail(Delivery delivery) {
+        return JobBuilder.newJob(CompleteJob.class)
+                .withIdentity("Delivery_" + delivery.getId() + "_Complete")
                 .usingJobData("deliveryId", delivery.getId())
                 .storeDurably()
                 .build();

--- a/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
@@ -172,6 +172,8 @@ public class DeliveryServiceImpl implements DeliveryService {
                 throw new CustomException(ErrorStatus.DELIVERY_ALREADY_SHIPPED);
             case CANCELLED:
                 throw new CustomException(ErrorStatus.DELIVERY_CANCELLED);
+            case COMPLETED:
+                throw new CustomException(ErrorStatus.DELIVERY_ALREADY_COMPLETED);
         }
 
         if (delivery.isShippingExtended())
@@ -208,6 +210,8 @@ public class DeliveryServiceImpl implements DeliveryService {
                 throw new CustomException(ErrorStatus.DELIVERY_ALREADY_SHIPPED);
             case CANCELLED:
                 throw new CustomException(ErrorStatus.DELIVERY_CANCELLED);
+            case COMPLETED:
+                throw new CustomException(ErrorStatus.DELIVERY_ALREADY_COMPLETED);
         }
 
         deliverySchedulerService.cancelDeliveryJob(delivery, "ExtendShipping");
@@ -237,7 +241,8 @@ public class DeliveryServiceImpl implements DeliveryService {
 
         DeliveryStatus deliveryStatus = delivery.getDeliveryStatus();
         if (deliveryStatus != DeliveryStatus.READY
-                && deliveryStatus != DeliveryStatus.SHIPPED)
+                && deliveryStatus != DeliveryStatus.SHIPPED
+                && deliveryStatus != DeliveryStatus.COMPLETED)
             return toResultDto(delivery, applyNum * ticket, null);
 
         MypageResponseDTO.AddressDto addressDto = toAddressDto(delivery.getAddress());
@@ -266,6 +271,8 @@ public class DeliveryServiceImpl implements DeliveryService {
                 throw new CustomException(ErrorStatus.DELIVERY_SHIPPING_EXPIRED);
             case CANCELLED:
                 throw new CustomException(ErrorStatus.DELIVERY_CANCELLED);
+            case COMPLETED:
+                throw new CustomException(ErrorStatus.DELIVERY_ALREADY_COMPLETED);
         }
 
         deliverySchedulerService.cancelDeliveryJob(delivery, "Shipping");
@@ -300,6 +307,8 @@ public class DeliveryServiceImpl implements DeliveryService {
                 throw new CustomException(ErrorStatus.DELIVERY_SHIPPING_EXPIRED);
             case CANCELLED:
                 throw new CustomException(ErrorStatus.DELIVERY_CANCELLED);
+            case COMPLETED:
+                throw new CustomException(ErrorStatus.DELIVERY_ALREADY_COMPLETED);
         }
 
         if (delivery.isAddressExtended())

--- a/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
@@ -154,7 +154,7 @@ public class DrawServiceImpl implements DrawService {
 
         RaffleStatus raffleStatus = raffle.getRaffleStatus();
         validateRaffleStatus(raffleStatus);
-        if (raffleStatus == RaffleStatus.ENDED)
+        if (raffleStatus != RaffleStatus.UNFULFILLED)
             throw new CustomException(ErrorStatus.DRAW_COMPLETED);
 
         int applyNum = applyRepository.countByRaffle(raffle);
@@ -177,6 +177,7 @@ public class DrawServiceImpl implements DrawService {
             case ENDED:
                 throw new CustomException(ErrorStatus.DRAW_COMPLETED);
             case FINISHED:
+            case COMPLETED:
                 throw new CustomException(ErrorStatus.DRAW_FINISHED);
         }
 
@@ -273,7 +274,7 @@ public class DrawServiceImpl implements DrawService {
     }
 
     private void validateCancel(Raffle raffle, RaffleStatus raffleStatus) {
-        if (raffleStatus == RaffleStatus.FINISHED)
+        if (raffleStatus == RaffleStatus.FINISHED || raffleStatus == RaffleStatus.COMPLETED)
             throw new CustomException(ErrorStatus.DRAW_FINISHED);
 
         if (raffleStatus == RaffleStatus.ENDED) {


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #104 

## 📝 작업 내용

운송장 입력 후 7일 경과 시 혹은 당첨자가 직접 수령 완료를 눌렀을 때 상태를 변경하고, 응모된 티켓을 개최자에게 전달하는 기능을 구현하였습니다.

RaffleStatus, DeliveryStatus에 모두 COMPLETED를 추가하여 수령 완료된 상태를 구분하였습니다.

### 📸 스크린샷 (선택)
7일 경과 전 당첨자가 직접 수령 완료
<img width="758" alt="image" src="https://github.com/user-attachments/assets/f4d51cea-2e2d-4337-9b63-7b7787b5dd7a" />

<img width="471" alt="image" src="https://github.com/user-attachments/assets/11649733-1893-4fbf-a907-ad952f35860f" />


수령 완료 처리 후 래플 상태 변경 (ENDED -> COMPLETED)
<img width="232" alt="image" src="https://github.com/user-attachments/assets/b1eaeaab-c801-4ae4-83e3-2361118ab170" />

배송 상태 변경(SHIPPED -> COMPLETED)
<img width="333" alt="image" src="https://github.com/user-attachments/assets/0de169b4-7637-4255-bda2-0e00a021d429" />

판매자에게 응모된 티켓 지급
<img width="231" alt="image" src="https://github.com/user-attachments/assets/0a21b132-e213-4b58-a005-abc511035aee" />


## 💬 리뷰 요구사항(선택)
운송장 입력 후 7일(168시간)이 지났을 경우 스케줄링을 통해 자동으로 상태 변환 및 판매자 티켓 지급이 진행됩니다.
