### PR TITLE
✨[FEAT] #119: 사용자의 레플 응모 상태 확인 추가

### DIFF
--- a/src/main/java/com/example/demo/domain/converter/RaffleConverter.java
+++ b/src/main/java/com/example/demo/domain/converter/RaffleConverter.java
@@ -33,7 +33,7 @@ public class RaffleConverter {
                 .build();
     }
 
-    public static RaffleResponseDTO.RaffleDetailDTO toDetailDTO(Raffle raffle, int likeCount, int applyCount, int followCount, int reviewCount) {
+    public static RaffleResponseDTO.RaffleDetailDTO toDetailDTO(Raffle raffle, int likeCount, int applyCount, int followCount, int reviewCount, String state) {
 
         return RaffleResponseDTO.RaffleDetailDTO.builder()
                 .imageUrls(raffle.getImages().stream().map(Image::getImageUrl).toList()) // 이미지 url 리스트 (추후 쿼리 개선)
@@ -50,6 +50,7 @@ public class RaffleConverter {
                 .nickname(raffle.getUser().getNickname()) // 판매자 닉네임
                 .followCount(followCount) // 팔로우 수
                 .reviewCount(reviewCount) // 리뷰 수
+                .state(state) // 응모상태
                 .build();
     }
 

--- a/src/main/java/com/example/demo/domain/dto/Raffle/RaffleResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Raffle/RaffleResponseDTO.java
@@ -38,6 +38,7 @@ public class RaffleResponseDTO {
         private String nickname;
         private int followCount;
         private int reviewCount;
+        private String state;
     }
 
     @Getter


### PR DESCRIPTION
## #⃣ 연관된 이슈

#119 

## 📝 작업 내용
<img width="779" alt="스크린샷 2025-02-07 오후 2 11 33" src="https://github.com/user-attachments/assets/58dd014e-6bfb-47ed-93c4-7fe6b95dd782" />

api/permit/** 경로를 통해 접근 시, 로그인 한 사용자와 로그인 하지 않은 사용자의 차이를 두었습니다.
검증 없이 다음 필터로 이동한 기존 방식에서,
로그인 한 사용자의 경우에는 SecurityContextHolder에 저장 후 다음 필터로 이동시키는 과정을 추가했습니다.

<img width="1010" alt="스크린샷 2025-02-07 오후 2 11 22" src="https://github.com/user-attachments/assets/49390635-0396-4e58-a9ae-41dcef40c9b0" />
이를 통해 레플 상세보기의 경우, api/permit/raffles/{raffleId}로 접근할 때, 현재 사용자에 따라 다른 state값을 갖도록 변경했습니다
