### PR TITLE
✨[FEAT] #123: 배송 정보에서 기본 배송지 조회

### DIFF
--- a/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DeliveryServiceImpl.java
@@ -44,12 +44,24 @@ public class DeliveryServiceImpl implements DeliveryService {
         Delivery delivery = getDeliveryById(deliveryId);
         validateWinner(delivery, user);
 
+        MypageResponseDTO.AddressDto addressDto = null;
+
         DeliveryStatus deliveryStatus = delivery.getDeliveryStatus();
         if (deliveryStatus == DeliveryStatus.WAITING_ADDRESS
-                || deliveryStatus == DeliveryStatus.WAITING_PAYMENT)
-            return toDeliveryDto(delivery, null);
+                || deliveryStatus == DeliveryStatus.WAITING_PAYMENT) {
 
-        MypageResponseDTO.AddressDto addressDto = toAddressDto(delivery.getAddress());
+            if (!user.getAddresses().isEmpty()) {
+                Address defaultAddress = user.getAddresses().stream()
+                        .filter(Address::isDefault)
+                        .findFirst()
+                        .orElseThrow(() -> new CustomException(ErrorStatus.DELIVERY_NO_DEFAULT_ADDRESS));
+
+                addressDto = toAddressDto(defaultAddress);
+            }
+
+        } else
+            addressDto = toAddressDto(delivery.getAddress());
+
         return toDeliveryDto(delivery, addressDto);
     }
 


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #123 

## 📝 작업 내용

주소 등록 전에는 주소를 null로 전달하였으나, 등록 전에도 기본 배송지로 등록된 주소를 전달하도록 수정하였습니다. 기본 배송지도 없는 경우에는 null을 전달합니다. 배송지 등록 후에는 해당 사용자의 기본 배송지를 변경하여도 등록된 주소로 조회됩니다.

### 📸 스크린샷 (선택)
등록 전 - 기본 배송지로 조회
<img width="492" alt="image" src="https://github.com/user-attachments/assets/da0c9c5a-7884-402b-847d-3cc8e3590a37" />

기본 배송지 변경 후에도 등록된 주소로 조회
<img width="560" alt="image" src="https://github.com/user-attachments/assets/d41d9fff-55b2-4eba-8314-69cf618454f5" />


## 💬 리뷰 요구사항(선택)
