### PR TITLE
✨[FEAT] #126: 래플 결과 조회 수정

### DIFF
--- a/src/main/java/com/example/demo/base/status/ErrorStatus.java
+++ b/src/main/java/com/example/demo/base/status/ErrorStatus.java
@@ -93,6 +93,8 @@ public enum ErrorStatus implements BaseErrorCode {
     DRAW_PENDING(HttpStatus.BAD_REQUEST, "DRAW_4006", "아직 추첨이 되지 않았습니다."),
     DRAW_COMPLETED(HttpStatus.BAD_REQUEST, "DRAW_4007", "이미 추첨이 완료되었습니다."),
     DRAW_FINISHED(HttpStatus.BAD_REQUEST, "DRAW_4008", "이미 종료된 래플입니다."),
+    DRAW_ALREADY_CHECKED(HttpStatus.BAD_REQUEST, "DRAW_4009", "이미 결과를 확인한 래플입니다"),
+    DRAW_OWNER(HttpStatus.BAD_REQUEST, "DRAW_4010", "래플의 개최자입니다."),
 
     // 14. Huiju - 배송 관련 에러
     DELIVERY_NOT_WINNER(HttpStatus.BAD_REQUEST, "DELIVERY_4001", "당첨자가 아닙니다."),

--- a/src/main/java/com/example/demo/controller/general/DrawController.java
+++ b/src/main/java/com/example/demo/controller/general/DrawController.java
@@ -19,21 +19,20 @@ public class DrawController {
 
     private final DrawService drawService;
 
-    @Operation(summary = "래플 결과 확인하기")
+    @Operation(summary = "응모자 - 래플 결과 확인하기")
     @GetMapping("/{raffleId}/draw")
-    public ApiResponse<?> drawRaffle(
-            @PathVariable Long raffleId, HttpServletResponse response) throws IOException {
+    public ApiResponse<DrawResponseDTO.DrawDto> drawRaffle(@PathVariable Long raffleId) {
 
-        DrawResponseDTO.RaffleResult result = drawService.getDrawRaffle(raffleId);
-        DrawResponseDTO.DrawDto drawDto = result.getDrawDto();
-        String redirectUrl = result.getRedirectUrl();
+        return ApiResponse.of(_OK, drawService.getDrawRaffle(raffleId));
+    }
 
-        if (drawDto == null){
-            response.sendRedirect(redirectUrl);
-            return null;
-        }
+    @Operation(summary = "응모자 - 래플 결과 조회 완료하기")
+    @PostMapping("/{raffleId}/check")
+    public ApiResponse<?> checkRaffle(@PathVariable Long raffleId) {
 
-        return ApiResponse.of(_OK, drawDto);
+        drawService.checkRaffle(raffleId);
+
+        return ApiResponse.of(_OK, null);
     }
 
     @Operation(summary = "개최자 - 래플 결과 확인하기")

--- a/src/main/java/com/example/demo/domain/converter/RaffleConverter.java
+++ b/src/main/java/com/example/demo/domain/converter/RaffleConverter.java
@@ -33,7 +33,7 @@ public class RaffleConverter {
                 .build();
     }
 
-    public static RaffleResponseDTO.RaffleDetailDTO toDetailDTO(Raffle raffle, int likeCount, int applyCount, int followCount, int reviewCount, String state, String isWinner, RaffleStatus raffleStatus) {
+    public static RaffleResponseDTO.RaffleDetailDTO toDetailDTO(Raffle raffle, int likeCount, int applyCount, int followCount, int reviewCount, String state, String isWinner, RaffleStatus raffleStatus, Long deliveryId) {
 
         return RaffleResponseDTO.RaffleDetailDTO.builder()
                 .imageUrls(raffle.getImages().stream().map(Image::getImageUrl).toList()) // 이미지 url 리스트 (추후 쿼리 개선)
@@ -53,6 +53,7 @@ public class RaffleConverter {
                 .userStatus(state) // 사용자 응모 상태
                 .isWinner(isWinner) // 당첨여부
                 .raffleStatus(raffleStatus) // 래플 상태
+                .deliveryId(deliveryId) // 배송 정보 아이디
                 .build();
     }
 

--- a/src/main/java/com/example/demo/domain/dto/DrawResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/DrawResponseDTO.java
@@ -42,13 +42,4 @@ public class DrawResponseDTO {
         private Long raffleId;
     }
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RaffleResult {
-        private String redirectUrl;
-        private DrawDto drawDto;
-    }
-
 }

--- a/src/main/java/com/example/demo/domain/dto/Raffle/RaffleResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Raffle/RaffleResponseDTO.java
@@ -43,6 +43,7 @@ public class RaffleResponseDTO {
         private String userStatus;
         private String isWinner;
         private RaffleStatus raffleStatus;
+        private Long deliveryId;
     }
 
     @Getter

--- a/src/main/java/com/example/demo/entity/Apply.java
+++ b/src/main/java/com/example/demo/entity/Apply.java
@@ -22,7 +22,11 @@ public class Apply extends BaseEntity{
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Builder.Default
+    private boolean isChecked = false;
+
     // TODO: 당첨여부 항목은 이후에 진행
     // private Result result;
 
+    public void setChecked() { this.isChecked = true; }
 }

--- a/src/main/java/com/example/demo/entity/base/enums/RaffleStatus.java
+++ b/src/main/java/com/example/demo/entity/base/enums/RaffleStatus.java
@@ -5,6 +5,6 @@ public enum RaffleStatus {
     ACTIVE,     // 응모 중
     UNFULFILLED,    // 최소 티켓 수 미충족 마감
     ENDED,       // 응모 마감 및 당첨자 추첨 완료
-    FINISHED,     // 완전 종료
+    CANCELLED,     // 완전 종료
     COMPLETED       // 상품 수령 완료
 }

--- a/src/main/java/com/example/demo/jobs/RaffleEndJob.java
+++ b/src/main/java/com/example/demo/jobs/RaffleEndJob.java
@@ -50,7 +50,7 @@ public class RaffleEndJob implements Job {
         updateRaffleStatus(raffle, RaffleStatus.ENDED);
 
         if (applyList == null || applyList.isEmpty()) {
-            updateRaffleStatus(raffle, RaffleStatus.FINISHED);
+            updateRaffleStatus(raffle, RaffleStatus.CANCELLED);
             return;
         }
 

--- a/src/main/java/com/example/demo/repository/ApplyRepository.java
+++ b/src/main/java/com/example/demo/repository/ApplyRepository.java
@@ -4,6 +4,7 @@ import com.example.demo.entity.Apply;
 import com.example.demo.entity.Raffle;
 import com.example.demo.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -27,4 +28,8 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     List<Object[]> countAppliesByRaffleIds(@Param("raffleIds") List<Long> raffleIds);
 
     Apply findByRaffleAndUser(Raffle raffle, User user);
+
+    @Modifying
+    @Query("UPDATE Apply a SET a.isChecked = false WHERE a.raffle = :raffle")
+    void updateUncheckedByRaffle(@Param("raffle") Raffle raffle);
 }

--- a/src/main/java/com/example/demo/repository/ApplyRepository.java
+++ b/src/main/java/com/example/demo/repository/ApplyRepository.java
@@ -26,6 +26,5 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Query("SELECT a.raffle.id, COUNT(a) FROM Apply a WHERE a.raffle.id IN :raffleIds GROUP BY a.raffle.id")
     List<Object[]> countAppliesByRaffleIds(@Param("raffleIds") List<Long> raffleIds);
 
-
-
+    Apply findByRaffleAndUser(Raffle raffle, User user);
 }

--- a/src/main/java/com/example/demo/repository/DeliveryRepository.java
+++ b/src/main/java/com/example/demo/repository/DeliveryRepository.java
@@ -15,4 +15,6 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     Delivery findByRaffleAndWinner(Raffle raffle, User winner);
 
     boolean existsByAddressAndDeliveryStatusIn(Address address, List<DeliveryStatus> status);
+
+    Delivery findByRaffleAndDeliveryStatusIn(Raffle raffle, List<DeliveryStatus> waitingAddress);
 }

--- a/src/main/java/com/example/demo/service/general/DrawService.java
+++ b/src/main/java/com/example/demo/service/general/DrawService.java
@@ -13,7 +13,9 @@ public interface DrawService {
 
     void cancel(Raffle raffle);
 
-    DrawResponseDTO.RaffleResult getDrawRaffle(Long raffleId);
+    DrawResponseDTO.DrawDto getDrawRaffle(Long raffleId);
+
+    void checkRaffle(Long raffleId);
 
     DrawResponseDTO.ResultDto getResult(Long raffleId);
 

--- a/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
@@ -110,7 +110,7 @@ public class DrawServiceImpl implements DrawService {
         if (raffleStatus == RaffleStatus.UNFULFILLED)
             throw new CustomException(ErrorStatus.DRAW_PENDING);
 
-        if (userApply.isChecked())
+        if (userApply.isChecked() && !user.equals(raffle.getWinner()))
             throw new CustomException(ErrorStatus.DRAW_ALREADY_CHECKED);
 
         List<Apply> applyList = applyRepository.findByRaffle(raffle);

--- a/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
@@ -267,6 +267,8 @@ public class DrawServiceImpl implements DrawService {
 
         Delivery delivery = draw(raffle, applyList);
 
+        applyRepository.updateUncheckedByRaffle(raffle);
+
         return String.format(Constants.DELIVERY_OWNER_URL, delivery.getId());
     }
 

--- a/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
@@ -83,12 +83,12 @@ public class DrawServiceImpl implements DrawService {
             userRepository.batchUpdateTicketNum(refundTicket, userIds);
         }
 
-        raffle.setRaffleStatus(RaffleStatus.FINISHED);
+        raffle.setRaffleStatus(RaffleStatus.CANCELLED);
         raffleRepository.save(raffle);
     }
 
     @Override
-    public DrawResponseDTO.RaffleResult getDrawRaffle(Long raffleId) {
+    public DrawResponseDTO.DrawDto getDrawRaffle(Long raffleId) {
 
         User user = getUser();
         Raffle raffle = getRaffle(raffleId);
@@ -99,22 +99,19 @@ public class DrawServiceImpl implements DrawService {
         Delivery delivery = deliveryRepository.findByRaffleAndWinner(raffle, raffle.getWinner());
 
         // 개최자인 경우
-        if (raffle.getUser().equals(user)) {
-            String redirectUrl = raffleStatus != RaffleStatus.UNFULFILLED ?
-                    String.format(Constants.DELIVERY_OWNER_URL, delivery.getId()) :
-                    String.format(Constants.RAFFLE_OWNER_URL, raffleId);
+        if (raffle.getUser().equals(user))
+            throw new CustomException(ErrorStatus.DRAW_OWNER);
 
-            return DrawResponseDTO.RaffleResult.builder()
-                    .drawDto(null)
-                    .redirectUrl(redirectUrl)
-                    .build();
-        }
+        Apply userApply = applyRepository.findByRaffleAndUser(raffle, user);
 
-        if (!applyRepository.existsByRaffleAndUser(raffle, user))
+        if (userApply == null)
             throw new CustomException(ErrorStatus.DRAW_NOT_IN);
 
         if (raffleStatus == RaffleStatus.UNFULFILLED)
             throw new CustomException(ErrorStatus.DRAW_PENDING);
+
+        if (userApply.isChecked())
+            throw new CustomException(ErrorStatus.DRAW_ALREADY_CHECKED);
 
         List<Apply> applyList = applyRepository.findByRaffle(raffle);
         if (applyList.isEmpty())
@@ -139,10 +136,34 @@ public class DrawServiceImpl implements DrawService {
         nicknameSet.add(user.getNickname());
         boolean isWin = raffle.getWinner().equals(user);
 
-        return DrawResponseDTO.RaffleResult.builder()
-                .drawDto(toDrawDto(delivery, nicknameSet, isWin))
-                .redirectUrl(null)
-                .build();
+        return toDrawDto(delivery, nicknameSet, isWin);
+    }
+
+    @Override
+    @Transactional
+    public void checkRaffle(Long raffleId) {
+        User user = getUser();
+        Raffle raffle = getRaffle(raffleId);
+
+        RaffleStatus raffleStatus = raffle.getRaffleStatus();
+        validateRaffleStatus(raffleStatus);
+        if (raffleStatus == RaffleStatus.UNFULFILLED)
+            throw new CustomException(ErrorStatus.DRAW_PENDING);
+
+        List<Apply> applyList = applyRepository.findByRaffle(raffle);
+        if (applyList.isEmpty())
+            throw new CustomException(ErrorStatus.DRAW_EMPTY);
+
+        Apply apply = applyRepository.findByRaffleAndUser(raffle, user);
+
+        if (apply == null)
+            throw new CustomException(ErrorStatus.DRAW_NOT_IN);
+
+        if (apply.isChecked())
+            throw new CustomException(ErrorStatus.DRAW_ALREADY_CHECKED);
+
+        apply.setChecked();
+        applyRepository.save(apply);
     }
 
     @Override
@@ -176,7 +197,7 @@ public class DrawServiceImpl implements DrawService {
         switch (raffleStatus) {
             case ENDED:
                 throw new CustomException(ErrorStatus.DRAW_COMPLETED);
-            case FINISHED:
+            case CANCELLED:
             case COMPLETED:
                 throw new CustomException(ErrorStatus.DRAW_FINISHED);
         }
@@ -274,7 +295,7 @@ public class DrawServiceImpl implements DrawService {
     }
 
     private void validateCancel(Raffle raffle, RaffleStatus raffleStatus) {
-        if (raffleStatus == RaffleStatus.FINISHED || raffleStatus == RaffleStatus.COMPLETED)
+        if (raffleStatus == RaffleStatus.CANCELLED || raffleStatus == RaffleStatus.COMPLETED)
             throw new CustomException(ErrorStatus.DRAW_FINISHED);
 
         if (raffleStatus == RaffleStatus.ENDED) {


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #126 

## 📝 작업 내용

Apply 엔티티에 사용자가 래플 결과 확인 유무를 나타내는 isChecked 속성을 추가하였습니다.
isChecked==false인 경우 래플 상세보기 시 isWinner: "hope"로 표시됩니다.

/raffles/{raffle-id}/draw를 통해 래플 결과를 확인 후 /raffles/{raffle-id}/check로 POST 요청을 받으면 isChecked=true로 변경합니다. 이후 해당 사용자가 동일한 래플의 결과를 조회할 경우 당첨자 외에는 모두 더이상 조회가 불가능합니다.

GET /raffles/{raffle-id}/draw 시 기존 코드에서는 개최자 또한 동일한 요청을 보낸다고 간주해 리디렉트 하였으나, 다른 요청을 보내는 것으로 수정하여 리디렉션 관련 코드는 삭제하였습니다.

래플 상세보기에서 개최자가 배송정보 페이지로 넘어갈 수 있도록 deliveryId도 함께 전달합니다.

### 📸 스크린샷 (선택)
결과 조회 전 래플 상세보기 - isWinner: "hope"
<img width="472" alt="image" src="https://github.com/user-attachments/assets/53605c3a-b915-4468-8310-f20136244ca8" />

결과 조회 완료
<img width="667" alt="image" src="https://github.com/user-attachments/assets/cc1ea6b3-87a4-4710-98ba-0102bcc07ff2" />

결과 조회 후 래플 상세보기 - isWinner: "no"
<img width="453" alt="image" src="https://github.com/user-attachments/assets/a7cb3c06-a740-480c-b45d-64ddce0de3b5" />

미당첨자의 두 번째 GET /raffles/{raffle-id}/draw
<img width="444" alt="image" src="https://github.com/user-attachments/assets/e8bdeaa5-7b2e-459f-af38-27d12033dd5f" />

개최자인 경우에만 래플 상세보기 시 delivery-id 전달
<img width="536" alt="image" src="https://github.com/user-attachments/assets/3df43e57-6c92-4202-9a86-5444fb206828" />




## 💬 리뷰 요구사항(선택)