### PR TITLE
✨[FEAT] #141:  잔여 시간 반환

### DIFF
--- a/src/main/java/com/example/demo/base/Constants.java
+++ b/src/main/java/com/example/demo/base/Constants.java
@@ -5,6 +5,9 @@ public class Constants {
     // 최대 주소 갯수
     public static final int MAX_ADDRESS_COUNT = 6;
 
+    // 수동 추첨 가능 기한 (시간 단위)
+    public static final int DRAW_DEADLINE = 24;
+
     // 배송지 입력 기한 (시간 단위)
     public static final int ADDRESS_DEADLINE = 72;
 

--- a/src/main/java/com/example/demo/domain/converter/DrawConverter.java
+++ b/src/main/java/com/example/demo/domain/converter/DrawConverter.java
@@ -1,11 +1,17 @@
 package com.example.demo.domain.converter;
 
+import com.example.demo.base.Constants;
 import com.example.demo.domain.dto.Draw.DrawResponseDTO;
 import com.example.demo.entity.Delivery;
 import com.example.demo.entity.Raffle;
 
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Set;
+
+import static java.time.LocalTime.from;
+import static java.time.LocalTime.now;
 
 public class DrawConverter {
 
@@ -23,11 +29,15 @@ public class DrawConverter {
     }
 
     public static DrawResponseDTO.ResultDto toResultDto(Raffle raffle, int applyTicket) {
+
+        Duration duration = Duration.between(now(), raffle.getEndAt().plusHours(Constants.DRAW_DEADLINE));
+
         return DrawResponseDTO.ResultDto.builder()
                 .raffleId(raffle.getId())
                 .minTicket(raffle.getMinTicket())
                 .applyTicket(applyTicket)
                 .totalAmount(BigDecimal.valueOf(applyTicket).multiply(new BigDecimal("93")))
+                .remainedMinutes(duration.toMinutes())
                 .build();
     }
 }

--- a/src/main/java/com/example/demo/domain/dto/Draw/DrawResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Draw/DrawResponseDTO.java
@@ -32,6 +32,7 @@ public class DrawResponseDTO {
         private int minTicket;
         private int applyTicket;
         private BigDecimal totalAmount;
+        private long remainedMinutes;
     }
 
     @Getter


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #141 

## 📝 작업 내용

개최자가 미충족 마감 래플의 결과 조회 시 마감 이후 24시간 이내인 경우로, 추첨 혹은 강제 종료를 선택가능할 때 선택 가능한 기한까지 남은 시간을 분으로 반환합니다.

### 📸 스크린샷 (선택)
미충족 마감 래플
<img width="393" alt="image" src="https://github.com/user-attachments/assets/8a8cca43-5788-4984-b5ae-148a35be941e" />

스웨거 확인 시각 2/17 00:28
<img width="375" alt="image" src="https://github.com/user-attachments/assets/5f108e7b-51b1-4df3-923b-01a073558095" />



## 💬 리뷰 요구사항(선택)

