### PR TITLE
✨[FEAT] #180: 스케줄링 API

### DIFF
--- a/src/main/java/com/example/demo/base/status/ErrorStatus.java
+++ b/src/main/java/com/example/demo/base/status/ErrorStatus.java
@@ -79,10 +79,8 @@ public enum ErrorStatus implements BaseErrorCode {
     JOB_EXECUTION_FAILED(HttpStatus.BAD_REQUEST, "JOB_4001", "Job 실행에 실패했습니다."),
     JOB_STORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JOB_5001", "Job 저장에 실패했습니다."),
     JOB_UNKNOWN(HttpStatus.INTERNAL_SERVER_ERROR, "JOB_5002", "알 수 없는 Job 에러가 발생했습니다."),
-    JOB_NOT_FOUND(HttpStatus.BAD_REQUEST, "JOB_4002", "Job을 찾을 수 없습니다."),
     JOB_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JOB_5003", "Job 취소에 실패했습니다."),
-    INVALID_DELIVERY_STATUS(HttpStatus.BAD_REQUEST, "JOB_4003", "Job 설정 가능한 배송 상태가 아닙니다."),
-    JOB_CREATION_FAILED(HttpStatus.BAD_REQUEST, "JOB_4004", "Job 생성에 실패했습니다."),
+    INVALID_DELIVERY_STATUS(HttpStatus.BAD_REQUEST, "JOB_4002", "Job 설정 가능한 배송 상태가 아닙니다."),
 
     // 13. Huiju - 당첨자 추첨 관련 에러
     DRAW_EMPTY(HttpStatus.BAD_REQUEST, "DRAW_4001", "응모한 사용자가 없습니다."),

--- a/src/main/java/com/example/demo/controller/admin/SchedulerController.java
+++ b/src/main/java/com/example/demo/controller/admin/SchedulerController.java
@@ -1,0 +1,36 @@
+package com.example.demo.controller.admin;
+
+import com.example.demo.base.ApiResponse;
+import com.example.demo.domain.dto.Scheduler.SchedulerResponseDTO;
+import com.example.demo.service.general.SchedulerService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.demo.base.status.SuccessStatus._OK;
+
+@RestController
+@RequestMapping("/api/permit/scheduler")
+@RequiredArgsConstructor
+public class SchedulerController {
+
+    private final SchedulerService schedulerService;
+
+    @Operation(summary = "스케줄링 조회")
+    @GetMapping("")
+    public ApiResponse<SchedulerResponseDTO> getJobKeys() {
+        return ApiResponse.of(_OK, schedulerService.getJobKeys());
+    }
+
+    @Operation(summary = "스케줄러 설정")
+    @PostMapping("")
+    public ApiResponse<?> scheduleAll() {
+        schedulerService.scheduleAll();
+
+        return ApiResponse.of(_OK, null);
+    }
+
+}

--- a/src/main/java/com/example/demo/controller/admin/SchedulerController.java
+++ b/src/main/java/com/example/demo/controller/admin/SchedulerController.java
@@ -5,10 +5,7 @@ import com.example.demo.domain.dto.Scheduler.SchedulerResponseDTO;
 import com.example.demo.service.general.SchedulerService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.example.demo.base.status.SuccessStatus._OK;
 
@@ -29,6 +26,14 @@ public class SchedulerController {
     @PostMapping("")
     public ApiResponse<?> scheduleAll() {
         schedulerService.scheduleAll();
+
+        return ApiResponse.of(_OK, null);
+    }
+
+    @Operation(summary = "새 래플 스케줄링")
+    @PostMapping("/new/{raffleId}")
+    public ApiResponse<?> scheduleNew(@PathVariable Long raffleId) {
+        schedulerService.scheduleNew(raffleId);
 
         return ApiResponse.of(_OK, null);
     }

--- a/src/main/java/com/example/demo/domain/dto/Scheduler/SchedulerResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/dto/Scheduler/SchedulerResponseDTO.java
@@ -1,0 +1,17 @@
+package com.example.demo.domain.dto.Scheduler;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.quartz.JobKey;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulerResponseDTO {
+    private Set<JobKey> JobKeys;
+}

--- a/src/main/java/com/example/demo/repository/RaffleRepository.java
+++ b/src/main/java/com/example/demo/repository/RaffleRepository.java
@@ -1,8 +1,10 @@
 package com.example.demo.repository;
 
 import com.example.demo.entity.Raffle;
+import com.example.demo.entity.base.enums.RaffleStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,4 +36,6 @@ public interface RaffleRepository extends JpaRepository<Raffle, Long> {
     List<Raffle> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
     List<Raffle> findAllByUserId(Long userId);
+
+    List<Raffle> findByRaffleStatusIn(List<RaffleStatus> statuses);
 }

--- a/src/main/java/com/example/demo/repository/RaffleRepository.java
+++ b/src/main/java/com/example/demo/repository/RaffleRepository.java
@@ -38,4 +38,7 @@ public interface RaffleRepository extends JpaRepository<Raffle, Long> {
     List<Raffle> findAllByUserId(Long userId);
 
     List<Raffle> findByRaffleStatusIn(List<RaffleStatus> statuses);
+
+    List<Raffle> findByIdGreaterThanEqualOrderByIdAsc(Long raffleId);
+
 }

--- a/src/main/java/com/example/demo/service/general/SchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/SchedulerService.java
@@ -17,7 +17,9 @@ public interface SchedulerService {
 
     void cancelRaffleJob(Raffle raffle);
 
+    SchedulerResponseDTO getJobKeys();
+
     void scheduleAll();
 
-    SchedulerResponseDTO getJobKeys();
+    void scheduleNew(Long raffleId);
 }

--- a/src/main/java/com/example/demo/service/general/SchedulerService.java
+++ b/src/main/java/com/example/demo/service/general/SchedulerService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.general;
 
+import com.example.demo.domain.dto.Scheduler.SchedulerResponseDTO;
 import com.example.demo.entity.Delivery;
 import com.example.demo.entity.Raffle;
 
@@ -15,4 +16,8 @@ public interface SchedulerService {
     void cancelDeliveryJob(Delivery delivery, String type);
 
     void cancelRaffleJob(Raffle raffle);
+
+    void scheduleAll();
+
+    SchedulerResponseDTO getJobKeys();
 }

--- a/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/DrawServiceImpl.java
@@ -39,6 +39,7 @@ public class DrawServiceImpl implements DrawService {
     private final UserRepository userRepository;
     private final EmailService emailService;
     private final SchedulerService schedulerService;
+    private final DeliveryRepository deliveryRepository;
 
     @Override
     @Transactional
@@ -55,6 +56,7 @@ public class DrawServiceImpl implements DrawService {
         delivery.setAddressDeadline();
 
         raffle.addDelivery(delivery);
+        deliveryRepository.save(delivery);
 
         emailService.sendWinnerPrizeEmail(delivery);
 

--- a/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/EmailServiceImpl.java
@@ -32,7 +32,7 @@ public class EmailServiceImpl implements EmailService {
     private String fromEmail;
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendWinnerPrizeEmail(Delivery delivery) {
         User user = delivery.getWinner();
         Raffle raffle = delivery.getRaffle();
@@ -67,7 +67,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendWinnerCancelEmail(Delivery delivery) {
         User user = delivery.getWinner();
         Raffle raffle = delivery.getRaffle();
@@ -98,7 +98,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendOwnerAddressExpiredEmail(Delivery delivery) {
         User user = delivery.getUser();
         Raffle raffle = delivery.getRaffle();
@@ -131,7 +131,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendOwnerCancelEmail(Raffle raffle) {
         User user = raffle.getUser();
 
@@ -162,7 +162,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendWinnerShippingExpiredEmail(Delivery delivery) {
         User user = delivery.getWinner();
         Raffle raffle = delivery.getRaffle();
@@ -194,7 +194,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendOwnerUnfulfilledEmail(Raffle raffle) {
         User user = raffle.getUser();
 
@@ -227,7 +227,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendOwnerReadyEmail(Delivery delivery) {
         User user = delivery.getUser();
         Raffle raffle = delivery.getRaffle();
@@ -301,7 +301,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Async("emailTaskExecutor")
+//    @Async("emailTaskExecutor")
     public void sendOwnerRaffleOpenEmail(Raffle raffle) {
         User user = raffle.getUser();
 

--- a/src/main/java/com/example/demo/service/general/impl/SchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/SchedulerServiceImpl.java
@@ -3,26 +3,31 @@ package com.example.demo.service.general.impl;
 import com.example.demo.base.Constants;
 import com.example.demo.base.code.exception.CustomException;
 import com.example.demo.base.status.ErrorStatus;
+import com.example.demo.domain.dto.Scheduler.SchedulerResponseDTO;
 import com.example.demo.entity.Delivery;
 import com.example.demo.entity.Raffle;
+import com.example.demo.entity.base.enums.DeliveryStatus;
 import com.example.demo.entity.base.enums.RaffleStatus;
 import com.example.demo.jobs.*;
+import com.example.demo.repository.DeliveryRepository;
+import com.example.demo.repository.RaffleRepository;
 import com.example.demo.service.general.SchedulerService;
 import lombok.RequiredArgsConstructor;
 import org.quartz.*;
+import org.quartz.impl.matchers.GroupMatcher;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Date;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class SchedulerServiceImpl implements SchedulerService {
 
     private final Scheduler scheduler;
+    private final RaffleRepository raffleRepository;
+    private final DeliveryRepository deliveryRepository;
 
     private void scheduleJob(String jobName, Class<? extends Job> jobClass, LocalDateTime time, Map<String, Object> jobData) {
         try {
@@ -57,6 +62,12 @@ public class SchedulerServiceImpl implements SchedulerService {
         LocalDateTime adjustedTime = time.withSecond(0).withNano(0);
         Date startDate = Date.from(adjustedTime.atZone(appZoneId).toInstant());
 
+        Date now = new Date();
+        if (startDate.before(now))
+            return TriggerBuilder.newTrigger()
+                    .startNow()
+                    .build();
+
         return TriggerBuilder.newTrigger()
                 .startAt(startDate)
                 .withSchedule(SimpleScheduleBuilder.simpleSchedule()
@@ -77,14 +88,15 @@ public class SchedulerServiceImpl implements SchedulerService {
 
     @Override
     public void scheduleRaffleJob(Raffle raffle) {
-        String startJobName = "Raffle_" + raffle.getId() + "_START";
-        LocalDateTime startTime = raffle.getStartAt();
-        scheduleJob(startJobName, RaffleStartJob.class, startTime, Map.of("raffleId", raffle.getId()));
+        if (raffle.getRaffleStatus() == RaffleStatus.UNOPENED) {
+            String startJobName = "Raffle_" + raffle.getId() + "_START";
+            LocalDateTime startTime = raffle.getStartAt();
+            scheduleJob(startJobName, RaffleStartJob.class, startTime, Map.of("raffleId", raffle.getId()));
+        }
 
         String endJobName = "Raffle_" + raffle.getId() + "_END";
         LocalDateTime endTime = raffle.getEndAt();
         scheduleJob(endJobName, RaffleEndJob.class, endTime, Map.of("raffleId", raffle.getId()));
-
     }
 
     @Override
@@ -118,11 +130,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             case ADDRESS_EXPIRED:
                 jobName += "_Waiting";
                 jobClass = WaitingJob.class;
-
-                if (!delivery.isAddressExtended())
-                    triggerTime = delivery.getAddressDeadline().plusHours(Constants.CHOICE_PERIOD);
-                else
-                    triggerTime = LocalDateTime.now().plusHours(Constants.CHOICE_PERIOD);
+                triggerTime = delivery.getAddressDeadline().plusHours(Constants.CHOICE_PERIOD);
                 break;
             case SHIPPING_EXPIRED:
                 jobName += "_Waiting";
@@ -145,8 +153,6 @@ public class SchedulerServiceImpl implements SchedulerService {
                 scheduler.unscheduleJob(triggerKey);
                 scheduler.deleteJob(jobKey);
             }
-//            else
-//                throw new CustomException(ErrorStatus.JOB_NOT_FOUND);
 
         } catch (SchedulerException e) {
             throw new CustomException(ErrorStatus.JOB_CANCEL_FAILED);
@@ -171,4 +177,78 @@ public class SchedulerServiceImpl implements SchedulerService {
         if (raffle.getRaffleStatus() == RaffleStatus.UNOPENED)
             cancelJob(jobName + "_START");
     }
+
+    @Override
+    public void scheduleAll() {
+        try {
+            if (!scheduler.isStarted())
+                scheduler.start();
+
+            if (!scheduler.getJobKeys(GroupMatcher.anyGroup()).isEmpty())
+                return;
+
+            List<Raffle> raffleList = raffleRepository.findByRaffleStatusIn(List.of(
+                    RaffleStatus.UNOPENED, RaffleStatus.ACTIVE, RaffleStatus.UNFULFILLED));
+
+            for (Raffle raffle : raffleList) {
+                switch (raffle.getRaffleStatus()) {
+                    case UNOPENED:
+                    case ACTIVE:
+                        scheduleRaffleJob(raffle);
+                        break;
+                    case UNFULFILLED:
+                        scheduleDrawJob(raffle);
+                        break;
+                }
+            }
+
+            raffleList = raffleRepository.findByRaffleStatusIn(List.of(RaffleStatus.ENDED));
+
+            for (Raffle raffle : raffleList) {
+                Delivery delivery = deliveryRepository.findByRaffleAndDeliveryStatusIn(raffle, List.of(
+                        DeliveryStatus.WAITING_ADDRESS, DeliveryStatus.READY, DeliveryStatus.SHIPPED,
+                        DeliveryStatus.ADDRESS_EXPIRED, DeliveryStatus.SHIPPING_EXPIRED));
+
+                if (delivery == null)
+                    continue;
+
+                switch (delivery.getDeliveryStatus()) {
+                    case WAITING_ADDRESS:
+                    case READY:
+                    case ADDRESS_EXPIRED:
+                    case SHIPPING_EXPIRED:
+                        scheduleDeliveryJob(delivery);
+                        break;
+
+                    case SHIPPED:
+                        String jobName = "Delivery_" + delivery.getId() + "_Complete";
+                         LocalDateTime triggerTime = delivery.getUpdatedAt().minusSeconds(0).withNano(0)
+                                .plusHours(Constants.COMPLETE);
+                        Class<? extends Job> jobClass = CompleteJob.class;
+
+                        scheduleJob(jobName, jobClass, triggerTime, Map.of("deliveryId", delivery.getId()));
+                        break;
+                }
+            }
+
+        } catch (SchedulerException e) {
+            handleSchedulerException(e);
+        }
+    }
+
+    @Override
+    public SchedulerResponseDTO getJobKeys() {
+        Set<JobKey> jobKeys = new HashSet<>();
+
+        try {
+            jobKeys = scheduler.getJobKeys(GroupMatcher.anyGroup());
+        } catch (SchedulerException e) {
+            handleSchedulerException(e);
+        }
+
+        return SchedulerResponseDTO.builder()
+                .JobKeys(jobKeys)
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/demo/service/general/impl/SchedulerServiceImpl.java
+++ b/src/main/java/com/example/demo/service/general/impl/SchedulerServiceImpl.java
@@ -241,7 +241,7 @@ public class SchedulerServiceImpl implements SchedulerService {
 
                     case SHIPPED:
                         String jobName = "Delivery_" + delivery.getId() + "_Complete";
-                         LocalDateTime triggerTime = delivery.getUpdatedAt().minusSeconds(0).withNano(0)
+                        LocalDateTime triggerTime = delivery.getUpdatedAt().withSecond(0).withNano(0)
                                 .plusHours(Constants.COMPLETE);
                         Class<? extends Job> jobClass = CompleteJob.class;
 


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #180 

## 📝 작업 내용

개발자용 스케줄링 API입니다.

GET /api/permit/scheduler 요청 시 현재 스케줄링 목록 조회가 가능합니다.

POST /api/permit/scheduler 요청은 백엔드 코드 푸시 후 요청하시면 됩니다. 
푸시 후 스케줄러가 리셋되기 때문에 전체 raffle, delivery에 대해 각 상태에 맞게 스케줄링 설정합니다.

랜덤 더미 데이터 생성 후에는 POST /api/permit/scheduler/new/{raffleId}로 새로운 래플 중 첫번째 래플의 아이디로 요청하시면 해당 아이디 이후 래플에 대해 스케줄링 설정합니다.
단, 이 API는 마감 전 래플에 대한 스케줄링만 설정하니 특정 상태의 래플을 만들고, 스케줄링 설정이 필요한 경우 제가 따로 카톡으로 안내드린 방법대로 API 추가 혹은 수정 필요합니다.

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
